### PR TITLE
Improved recognition of PGP/GPG encrypted files.

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -755,7 +755,7 @@ isfinal() {
     iconv -c -f ISO-8859-1 "$2"
   elif [[ "$1" = *UTF-16$NOL_A_P* && $LANG != *UTF-16 ]] && cmd_exist iconv -c; then
     iconv -c -f UTF-16 "$2"
-  elif [[ "$1" = *GPG\ encrypted\ data* ]] && cmd_exist gpg; then
+  elif [[ "$1" = *GPG\ encrypted\ data* || "$1" = *PGP\ *ncrypted* ]] && cmd_exist gpg; then
     msg "append $sep to filename to view the encrypted file"
     gpg -d "$2"
   elif [[ "$1" = *Apple\ binary\ property\ list* ]] && cmd_exist plutil; then

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -977,7 +977,7 @@ isfinal() {
     iconv -f UTF-16 "$2"
 #endif
 #ifdef gpg
-  elif [[ "$1" = *GPG\ encrypted\ data* ]] && cmd_exist gpg; then
+  elif [[ "$1" = *GPG\ encrypted\ data* || "$1" = *PGP\ *ncrypted* ]] && cmd_exist gpg; then
     msg "append $sep to filename to view the encrypted file"
     gpg -d "$2"
 #endif


### PR DESCRIPTION
The old pattern matches only 'GPG encrypted data'.

Whether an artifact of my file(1) command, or the extreme age of some
of my PGP-encrypted files, not all return that string:

<pre>
$ file -L *pgp *gpg *asc | sed -r 's/^[^:]+: +//; s/keyid: [A-F0-9]+ [A-F0-9]+ / HHHH /' \
        | sort | uniq -c
      1 ASCII text
    204 GPG encrypted data
    152 PGP RSA encrypted session key -  HHHH RSA (Encrypt or Sign) 2048b
    217 PGP RSA encrypted session key -  HHHH RSA (Encrypt or Sign) 2048b .
     15 PGP RSA encrypted session key -  HHHH RSA (Encrypt or Sign) 4096b
     12 PGP message Public-Key Encrypted Session Key (old)
</pre>

gpg -d can decrypt all of these fine (provided the key is available,
etc.).  They just were not recognized by lesspipe.sh and were being
treated as raw data.

This update matches the different 'PGP ...' outputs as well.
