### PR TITLE
Add support for viewing SSL related files with openssl(1)

### DIFF
--- a/README
+++ b/README
@@ -199,6 +199,7 @@ Contents
 		with lesspipe)
  nc4		requires ncdump (NetCDF format)
  hdf5		requires h5dump (Hierarchical Data Format)
+ crt, pem, csr, crl requires openssl
 
 4.3 Conversion of files with alternate character encoding
 ---------------------------------------------------------

--- a/configure
+++ b/configure
@@ -446,6 +446,7 @@ mp3info2	N	# code for mp3info2 is included anyway if id3v2 selected
 identify	Y
 isoinfo		Y	# I would not want to see that
 o3tohtml	Y
+openssl		Y
 perldoc		Y
 ppthtml		Y
 unrtf		Y

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -764,6 +764,15 @@ isfinal() {
   elif [[ "$1" = *data$NOL_A_P* ]]; then
     msg "append $sep to filename to view the raw data"
     nodash strings "$2"
+  elif [[ "$2" = *.crt || "$2" = *.pem ]] && cmd_exist openssl; then
+    msg "append $sep to filename to view the raw data"
+    openssl x509 -hash -text -noout -in "$2"
+  elif [[ "$2" = *.csr ]] && cmd_exist openssl; then
+    msg "append $sep to filename to view the raw data"
+    openssl req -text -noout -in "$2"
+  elif [[ "$2" = *.crl ]] && cmd_exist openssl; then
+    msg "append $sep to filename to view the raw data"
+    openssl crl -hash -text -noout -in "$2"
   else
     set "plain text" "$2"
   fi

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -989,6 +989,17 @@ isfinal() {
   elif [[ "$1" = *data$NOL_A_P* ]]; then
     msg "append $sep to filename to view the raw data"
     nodash strings "$2"
+#ifdef openssl
+  elif [[ "$2" = *.crt || "$2" = *.pem ]] && cmd_exist openssl; then
+    msg "append $sep to filename to view the raw data"
+    openssl x509 -hash -text -noout -in "$2"
+  elif [[ "$2" = *.csr ]] && cmd_exist openssl; then
+    msg "append $sep to filename to view the raw data"
+    openssl req -text -noout -in "$2"
+  elif [[ "$2" = *.crl ]] && cmd_exist openssl; then
+    msg "append $sep to filename to view the raw data"
+    openssl crl -hash -text -noout -in "$2"
+#endif
   else
     set "plain text" "$2"
   fi


### PR DESCRIPTION
Viewing those files raw gives you little information, so it'd be helpful if lesspipe could show them in a readable format.