### PR TITLE
Add matdump support

### DIFF
--- a/configure
+++ b/configure
@@ -440,6 +440,7 @@ pdftohtml	Y
 pdftotext	Y
 # other helper programs
 cabextract	Y
+matdump	N
 djvutxt		Y
 fastjar		N	# I do prefer unzip
 gpg		Y
@@ -449,7 +450,6 @@ mp3info2	N	# code for mp3info2 is included anyway if id3v2 selected
 identify	Y
 isoinfo		Y	# I would not want to see that
 o3tohtml	Y
-matdump	N
 openssl		Y
 perldoc		Y
 ppthtml		Y

--- a/configure
+++ b/configure
@@ -449,6 +449,7 @@ mp3info2	N	# code for mp3info2 is included anyway if id3v2 selected
 identify	Y
 isoinfo		Y	# I would not want to see that
 o3tohtml	Y
+matdump	N
 openssl		Y
 perldoc		Y
 ppthtml		Y

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -893,6 +893,11 @@ isfinal() {
   elif [[ "$1" = *NetCDF* || "$1" = *Hierarchical\ Data\ Format* ]] && cmd_exist ncdump; then
     istemp ncdump "$2"
 #endif
+#ifdef matdump
+  elif [[ "$1" = *Matlab\ v[0-9.]*\ mat-file* ]] && cmd_exist matdump; then
+    msg "append $sep to filename to view the raw data"
+    matdump -d "$2"
+#endif
 #ifdef djvutxt
   elif [[ "$1" = *DjVu* ]] && cmd_exist djvutxt; then
     msg "append $sep to filename to view the DjVu source"
@@ -1029,11 +1034,6 @@ isfinal() {
   elif [[ "$1" = *data$NOL_A_P* ]]; then
     msg "append $sep to filename to view the raw data"
     nodash strings "$2"
-#ifdef matdump
-  elif [[ "$1" = *Matlab\ v[0-9.]*\ mat-file* ]] && cmd_exist matdump; then
-    msg "append $sep to filename to view the raw data"
-    matdump -d "$2"
-#endif
 #ifdef openssl
   elif [[ "$2" = *.crt || "$2" = *.pem ]] && cmd_exist openssl; then
     msg "append $sep to filename to view the raw data"

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -1029,6 +1029,11 @@ isfinal() {
   elif [[ "$1" = *data$NOL_A_P* ]]; then
     msg "append $sep to filename to view the raw data"
     nodash strings "$2"
+#ifdef matdump
+  elif [[ "$1" = *Matlab\ v[0-9.]*\ mat-file* ]] && cmd_exist matdump; then
+    msg "append $sep to filename to view the raw data"
+    matdump -d "$2"
+#endif
 #ifdef openssl
   elif [[ "$2" = *.crt || "$2" = *.pem ]] && cmd_exist openssl; then
     msg "append $sep to filename to view the raw data"


### PR DESCRIPTION
I would like to add support for older MatLab [MAT-Files](https://www.mathworks.com/help/matlab/import_export/load-parts-of-variables-from-mat-files.html) (including MAT-Files before version 7.3).

The dependent `matdump` comes from [matio](https://github.com/openmeeg/matio-openmeeg).