### PR TITLE
Add -M4294967295 to zstd options

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -109,14 +109,16 @@ filetype () {
   typeset name
   name="$1"
   if [[ "$1" = - ]]; then
-    dd bs=40000 count=1 > "$tmpdir/file" 2>/dev/null
-    set "$tmpdir/file" "$2"
     name="$filen"
   fi
   if [[ ("$name" = *.br || "$name" = *.bro || "$name" = *.tbr) ]]; then
     # In current format, brotli can only be detected by extension
     echo " brotli compressed data"
     return
+  fi
+  if [[ "$1" = - ]]; then
+    dd bs=40000 count=1 > "$tmpdir/file" 2>/dev/null
+    set "$tmpdir/file" "$2"
   fi
   typeset type
   # type=" $(filecmd -b "$1")" # not supported by all versions of 'file'

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -302,7 +302,7 @@ get_cmd () {
        *.txz) filen="${filen%.txz}.tar";;
       esac
     elif [[ "$1" = *Zstandard\ compressed* ]] && cmd_exist zstd; then
-      cmd=(zstd -cdq "$2")
+      cmd=(zstd -cdqM4294967295 "$2")
       if [[ "$2" != - ]]; then filen="$2"; fi
       case "$filen" in
        *.zst) filen="${filen%.zst}";;
@@ -506,7 +506,7 @@ unpack_cmd() {
     elif [[ "$1" == *lzma ]]; then
       cmd_string="lzma -dc -"
     elif [[ "$1" == *zst ]]; then
-      cmd_string="zstd -dcq -"
+      cmd_string="zstd -dcqM4294967295 -"
     elif [[ ("$1" == *br || "$1" == *bro) ]]; then
       cmd_string="brotli -dc -"
     elif [[ "$1" == *lz4 ]]; then

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -111,8 +111,6 @@ filetype () {
   typeset name
   name="$1"
   if [[ "$1" = - ]]; then
-    dd bs=40000 count=1 > "$tmpdir/file" 2>/dev/null
-    set "$tmpdir/file" "$2"
     name="$filen"
   fi
 #ifdef brotli
@@ -122,6 +120,10 @@ filetype () {
     return
   fi
 #endif
+  if [[ "$1" = - ]]; then
+    dd bs=40000 count=1 > "$tmpdir/file" 2>/dev/null
+    set "$tmpdir/file" "$2"
+  fi
   typeset type
   # type=" $(filecmd -b "$1")" # not supported by all versions of 'file'
   type=$(filecmd "$1" | cut -d : -f 2-)

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -318,7 +318,7 @@ get_cmd () {
 #endif
 #ifdef zstd
     elif [[ "$1" = *Zstandard\ compressed* ]] && cmd_exist zstd; then
-      set -A cmd zstd -cdq "$2"
+      set -A cmd zstd -cdqM4294967295 "$2"
       if [[ "$2" != - ]]; then filen="$2"; fi
       case "$filen" in
        *.zst) filen="${filen%.zst}";;
@@ -584,7 +584,7 @@ unpack_cmd() {
     elif [[ "$1" == *lzma ]]; then
       cmd_string="lzma -dc -"
     elif [[ "$1" == *zst ]]; then
-      cmd_string="zstd -dcq -"
+      cmd_string="zstd -dcqM4294967295 -"
     elif [[ ("$1" == *br || "$1" == *bro) ]]; then
       cmd_string="brotli -dc -"
     elif [[ "$1" == *lz4 ]]; then


### PR DESCRIPTION
Without that option, zstd will refuse to decompress archives which have
been created with option --long=28 or larger (for testing, one must compress
from a pipe, because zstd shrinks the --long value according to the filesize
if no pipe is used).

The huge number passed covers the maximal possible value --long=31.
Usage of the huge number is safe if the file can be decompressed with less
memory: The memory allocated by zstd is only large if that amount is really
*needed* to decompress the file. For instance, if you decompress a _short_
file generated with cat ... | zstd --ultra -22 --long=31 >...
also only a small amount of memory is allocated, independent of the -M option.
