### PR TITLE
add libreoffice et al to view Microsoft Office 2007+, ODT and EPUB files

### DIFF
--- a/README
+++ b/README
@@ -179,14 +179,15 @@ Contents
  Microsoft Word < 2007	requires antiword or catdoc
  MS Powerpoint < 2007	requires ppthtml
  MS Excel < 2007	requires xlhtml
- Microsoft Word (docx) >= 2007	requires libreoffice, pandoc or doc2txt.pl
+ Microsoft Word (docx) >= 2007	requires libreoffice or pandoc or doc2txt.pl
  MS Powerpoint (pptx) >= 2007	requires libreoffice
  MS Excel (xlsx) >= 2007	requires libreoffice
+ epub requires pandoc
  Debian 	requires ar, gzip and tar, shows more info if dpkg is installed
  html		requires html2text or elinks or links or lynx or w3m
  pdf		requires pdftotext or pdftohtml
  perl		requires pod2text
- rtf		requires unrtf
+ rtf		requires pandoc or libreoffice or unrtf
  dvi		requires dvi2tty
  djvu		requires djvutxt
  ps		requires pstotext or ps2ascii (from the gs package)
@@ -201,8 +202,8 @@ Contents
  perl storable	requires perl (and the perl modules Storable and Data::Dumper)
  perl pod       requires perldoc
  OASIS		Opendocument text documents (used for Openoffice, Libreoffice)
- 		requires unzip and o3tohtml or sxw2txt (distributed together
-		with lesspipe)
+ 		requires libreoffice or pandoc or unzip and o3tohtml or sxw2txt
+ 	  (distributed together with lesspipe)
  nc4		requires ncdump (NetCDF format)
  hdf5		requires h5dump (Hierarchical Data Format)
  crt, pem, csr, crl requires openssl
@@ -427,14 +428,17 @@ less diagram.png
 
 9.1 URLs to some utilities
 --------------------------
- antiword   http://www.winfield.demon.nl/
- html2text  http://www.mbayer.de/html2text/
- cabextract http://www.cabextract.org.uk/
- 7za        https://sourceforge.net/projects/p7zip/
- lzip       http://download.savannah.gnu.org/releases/lzip/
- dvi2tty    http://www.ctan.org/tex-archive/dviware/dvi2tty/
- unrtf      http://ftp.gnu.org/gnu/unrtf/
- id3v2      http://id3v2.sourceforge.net/
+ antiword     http://www.winfield.demon.nl/
+ html2text    http://www.mbayer.de/html2text/
+ cabextract   http://www.cabextract.org.uk/
+ 7za          https://sourceforge.net/projects/p7zip/
+ lzip         http://download.savannah.gnu.org/releases/lzip/
+ dvi2tty      http://www.ctan.org/tex-archive/dviware/dvi2tty/
+ unrtf        http://ftp.gnu.org/gnu/unrtf/
+ docx2txt.pl  https://github.com/arthursucks/docx2txt
+ pandoc       http://pandoc.org
+ libreoffice  http://www.libreoffice.org
+ id3v2        http://id3v2.sourceforge.net/
 
 9.2 References
 --------------

--- a/README
+++ b/README
@@ -128,11 +128,11 @@ Contents
 
  Code for using LESS_ADVANCED_PREPROCESSOR is optionally generated (configure).
  LESS_ADVANCED_PREPROCESSOR will switch on filtering methods for html, rtf, ps
- files and files with alternate character encoding, if this variable is set. 
+ files and files with alternate character encoding, if this variable is set.
  Filtering these formats is also done if there is no LESS_ADVANCED_PREPROCESSOR
  support (then this string is not contained in lesspipe.sh). Otherwise these
  types of files will be shown unmodified.
- 
+
 3. Required programs
 ====================
 
@@ -176,9 +176,12 @@ Contents
  executable	requires strings
  directory	displayed using ls -lA
  RPM		requires GNU cpio and rpm2cpio or rpmunpack, optionally rpm
- Microsoft Word	requires antiword or catdoc
- MS Powerpoint	requires ppthtml
- MS Excel	requires xlhtml
+ Microsoft Word < 2007	requires antiword or catdoc
+ MS Powerpoint < 2007	requires ppthtml
+ MS Excel < 2007	requires xlhtml
+ Microsoft Word (docx) >= 2007	requires libreoffice, pandoc or doc2txt.pl
+ MS Powerpoint (pptx) >= 2007	requires libreoffice
+ MS Excel (xlsx) >= 2007	requires libreoffice
  Debian 	requires ar, gzip and tar, shows more info if dpkg is installed
  html		requires html2text or elinks or links or lynx or w3m
  pdf		requires pdftotext or pdftohtml
@@ -276,14 +279,14 @@ Contents
 
  The function code2color contains code to guarantee that color codes are only
  sent if less is called with one of the options -r or -R. To ensure that these
- checks are always performed, alternate syntax colorizers will be called 
+ checks are always performed, alternate syntax colorizers will be called
  from within code2color by setting the environment variable LESSCOLORIZER
  to the name of another program. Currently only pygmentize (and code2color as
  the default) is allowed. This can be changed in the first lines of code2color.
 
  Much better syntax highlighting is obtained using the less emulation of vim:
  The editor vim comes with a file less.sh, in my case located in
- /usr/share/vim/vim73/macros. Assuming that file location 
+ /usr/share/vim/vim73/macros. Assuming that file location
  a function lessc (bash, zsh, ksh users)
 
 	lessc () { /usr/share/vim/vim73/macros/less.sh "$@"}
@@ -291,7 +294,7 @@ Contents
  or an alias lessc (csh, tcsh users)
 
 	alias lessc /usr/share/vim/vim73/macros/less.sh
- 
+
  is defined and "lessc filename" is used to view the colorful file contents.
 
 5.2 Colored Directory listing
@@ -356,7 +359,7 @@ less file-4.26-3.fc10.src.rpm:file-4.26.tar.gz:file-4.26/doc/file.man
  The subcomponents of the argument to less were easily obtained by cut and
  paste using information contained in the previous lines of output.
  Care has been taken to display the subcomponents already in the way
- required by lesspipe, so that in most cases double clicking will select it. 
+ required by lesspipe, so that in most cases double clicking will select it.
  If the nroff sources should have been displayed instead, appending
  another colon at the end of the argument would have done the job:
 

--- a/configure
+++ b/configure
@@ -429,6 +429,9 @@ rpmunpack	N	# fallback for rpm2cpio only, code inserted anyway
 rpm2cpio	Y
 w3m		Y
 # code for these programs should be included in lesspipe.sh
+doc2txt.pl	Y	  # to view Microsoft Word 2007+ files
+pandoc	    Y	      # to view Microsoft Word 2007+ files
+libreoffice	Y	  # to view Microsoft Office 2007+ files
 antiword	Y	# one of antiword or catdoc should be installed
 catdoc		Y
 dvi2tty		Y	# nice to have

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -905,6 +905,36 @@ isfinal() {
     msg "append $sep to filename to view the DjVu source"
     djvutxt "$2"
 #endif
+#ifdef docx2txt.pl
+  elif [[ "$1" = *Microsoft\ Word\ 2007* ]]; then
+    if cmd_exist docx2txt.pl; then
+      msg "append $sep to filename to view the raw word document"
+      docx2txt.pl "$2"
+    else
+      msg "install docx2txt.pl to view human readable text"
+      cat "$2"
+    fi
+#elif doc2txt.pl
+#ifdef pandoc
+  elif [[ "$1" = *Microsoft\ Word\ 2007* ]]; then
+    if cmd_exist pandoc; then
+      msg "append $sep to filename to view the raw word document"
+      pandoc --from=docx --to=plain "$2"
+    else
+      msg "install docx2txt.pl to view human readable text"
+      cat "$2"
+    fi
+#elif pandoc
+#ifdef libreoffice
+  elif [[ "$1" = *Microsoft\ [[:alpha:]]*\ 2007* ]]; then
+    if cmd_exist libreoffice; then
+      msg "append $sep to filename to view the raw word document"
+      libreoffice --headless --cat "$2"
+    else
+      msg "install LibreOffice to view human readable text"
+      cat "$2"
+    fi
+#elif libreoffice
 #ifdef antiword
   elif [[ "$1" = *Microsoft\ Word* || "$1" = *Microsoft\ Office* ]]; then
     if cmd_exist antiword; then

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -921,12 +921,30 @@ isfinal() {
       msg "append $sep to filename to view the raw word document"
       pandoc --from=docx --to=plain "$2"
     else
-      msg "install docx2txt.pl to view human readable text"
+      msg "install pandoc to view human readable text"
+      cat "$2"
+    fi
+  elif [[ "$1" = *EPUB\ document* ]]; then
+    if cmd_exist pandoc; then
+      msg "append $sep to filename to view the raw word document"
+      pandoc --from=epub --to=plain "$2"
+    else
+      msg "install pandoc to view human readable text"
+      cat "$2"
+    fi
+  elif [[ "$1" = *OpenDocument\ Text* || "$1" = *OpenOffice\.org\ 1\.x\ [CIWdgpst]* ]]; then
+    if cmd_exist pandoc; then
+      msg "append $sep to filename to view the raw word document"
+      pandoc --from=odt --to=plain "$2"
+    else
+      msg "install pandoc to view human readable text"
       cat "$2"
     fi
 #elif pandoc
 #ifdef libreoffice
-  elif [[ "$1" = *Microsoft\ [[:alpha:]]*\ 2007* ]]; then
+  elif [[ "$1" = *Microsoft\ [[:alpha:]]*\ 2007* ||
+    "$1" = *Rich\ Text\ Format$NOL_A_P* ||
+    ("$1" = *OpenDocument\ Text* || "$1" = *OpenOffice\.org\ 1\.x\ [CIWdgpst]*) ]]; then
     if cmd_exist libreoffice; then
       msg "append $sep to filename to view the raw word document"
       libreoffice --headless --cat "$2"


### PR DESCRIPTION
This is mainly stolen from https://github.com/Konfekt/vim-office/blob/master/ftdetect/office.vim that lists also other, less common handlers, often giving better results.