### PR TITLE
PDF: Fix call to pdftotext with HTML support

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -773,7 +773,7 @@ isfinal() {
   elif [[ "$1" = *PDF* ]] && cmd_exist pdftotext; then
     if [[ "$PARSEHTML" = yes ]]; then
       msg "append $sep to filename to view the PDF source"
-      istemp pdftotext -htmlmeta "$2" - | parsehtml
+      istemp "pdftotext -htmlmeta" "$2" - | parsehtml -
     else
       msg "append $sep to filename to view the PDF source"
       istemp pdftotext "$2" -

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -944,7 +944,7 @@ isfinal() {
   elif [[ "$1" = *PDF* ]] && cmd_exist pdftotext; then
     if [[ "$PARSEHTML" = yes ]]; then
       msg "append $sep to filename to view the PDF source"
-      istemp pdftotext -htmlmeta "$2" - | parsehtml
+      istemp "pdftotext -htmlmeta" "$2" - | parsehtml -
     else
       msg "append $sep to filename to view the PDF source"
       istemp pdftotext "$2" -


### PR DESCRIPTION
Having a HTML to text converter installed on the host leads to having
pdftotext called with the extra "-htmlmeta" param. However, the command
wasn't properly passed to istemp.

Also fix next chained command.

Signed-off-by: Bogdan Purcareata <bogdan.purcareata@gmail.com>