### PR TITLE
Correcting argument to code2color

### DIFF
--- a/code2color
+++ b/code2color
@@ -290,6 +290,13 @@ sub main {
 
   }
 
+####
+#### trim leading trailing spaces
+####
+sub c2c_trim {
+    (my $s = $_[0]) =~ s/^\s+|\s+$//g;
+    return $s;
+}
 
 ####
 #### parse_passed_params
@@ -3266,7 +3273,7 @@ getopts('i:l:') || exit 2;
   $str = main(parse_passed_params( infile        => $ARGV[0] || '-',
              outfile       => '-',
 #             linenumbers   => 1 ,
-             langmode   => $opt_l ,
+             langmode   => c2c_trim($opt_l) ,
              outputformat  => 'xterm' ,
              # many other options
            ));

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -589,7 +589,7 @@ isfinal() {
       msg "append :. or :<filetype> to activate syntax highlighting"
     else
       lang=${3#$sep}
-      lang="-l ${lang#.}"
+      lang="-l${lang#.}"
       lang=${lang%%-l }
       if cmd_exist code2color; then
         code2color $PPID ${in_file:+"$in_file"} "$lang" "$2"

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -669,7 +669,7 @@ isfinal() {
       msg "append :. or :<filetype> to activate syntax highlighting"
     else
       lang=${3#$sep}
-      lang="-l ${lang#.}"
+      lang="-l${lang#.}"
       lang=${lang%%-l }
       if cmd_exist code2color; then
         code2color $PPID ${in_file:+"$in_file"} "$lang" "$2"


### PR DESCRIPTION
lang="-l ${lang#.}"

to

lang="-l${lang#.}"

as when calling with lang=c

code2color $PPID ${in_file:+"$in_file"} "$lang" "$2"

shell see "-l c" so " c" is received by code2color