### PR TITLE
Removing code2color change of extraneous c2c_trim subroutine

### DIFF
--- a/code2color
+++ b/code2color
@@ -290,13 +290,6 @@ sub main {
 
   }
 
-####
-#### trim leading trailing spaces
-####
-sub c2c_trim {
-    (my $s = $_[0]) =~ s/^\s+|\s+$//g;
-    return $s;
-}
 
 ####
 #### parse_passed_params
@@ -3273,7 +3266,7 @@ getopts('i:l:') || exit 2;
   $str = main(parse_passed_params( infile        => $ARGV[0] || '-',
              outfile       => '-',
 #             linenumbers   => 1 ,
-             langmode   => c2c_trim($opt_l) ,
+             langmode   => $opt_l ,
              outputformat  => 'xterm' ,
              # many other options
            ));


### PR DESCRIPTION
in 9c674c45f9549fee1c0eab2f2e7cf6d18e34be3f