### PR TITLE
Change zstd memory limit to 1073741824 bytes.

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -366,7 +366,7 @@ get_cmd () {
        *.txz) filen="${filen%.txz}.tar";;
       esac
     elif [[ "$1" = *Zstandard\ compressed* ]] && cmd_exist zstd; then
-      cmd=(zstd -cdqM4294967295 "$2")
+      cmd=(zstd -cdqM1073741824 "$2")
       if [[ "$2" != - ]]; then filen="$2"; fi
       case "$filen" in
        *.zst) filen="${filen%.zst}";;
@@ -570,7 +570,7 @@ unpack_cmd() {
     elif [[ "$1" == *lzma ]]; then
       cmd_string="lzma -dc -"
     elif [[ "$1" == *zst ]]; then
-      cmd_string="zstd -dcqM4294967295 -"
+      cmd_string="zstd -dcqM1073741824 -"
     elif [[ ("$1" == *br || "$1" == *bro) ]]; then
       cmd_string="brotli -dc -"
     elif [[ "$1" == *lz4 ]]; then

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -382,7 +382,7 @@ get_cmd () {
 #endif
 #ifdef zstd
     elif [[ "$1" = *Zstandard\ compressed* ]] && cmd_exist zstd; then
-      set -A cmd zstd -cdqM4294967295 "$2"
+      set -A cmd zstd -cdqM1073741824 "$2"
       if [[ "$2" != - ]]; then filen="$2"; fi
       case "$filen" in
        *.zst) filen="${filen%.zst}";;
@@ -648,7 +648,7 @@ unpack_cmd() {
     elif [[ "$1" == *lzma ]]; then
       cmd_string="lzma -dc -"
     elif [[ "$1" == *zst ]]; then
-      cmd_string="zstd -dcqM4294967295 -"
+      cmd_string="zstd -dcqM1073741824 -"
     elif [[ ("$1" == *br || "$1" == *bro) ]]; then
       cmd_string="brotli -dc -"
     elif [[ "$1" == *lz4 ]]; then


### PR DESCRIPTION
zstd will no longer accept 4294967295 as a memory limit, stating that
it's too large. The actual accepted limit is system-dependent; 1<<30 for
32-bit systems, and 1<<31 for 64-bit systems.

Here I chose the 32-bit limit, as that should only break for archives
created with --long=31 on 64-bit systems, whereas the 64-bit choice
would break on all 32-bit systems.

See 87ac1d025ba3417d7703b3ca57d52da055b5b21e for more details.