### PR TITLE
Make wvText use /dev/stdout instead of -.

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -837,7 +837,7 @@ isfinal() {
     fi
   elif [[ "$1" = *Microsoft\ Word\ Document* ]] && cmd_exist wvText; then
     msg "append $sep to filename to view the raw word document"
-    wvText "$2" -
+    wvText "$2" /dev/stdout
   elif [[ "$1" = *Microsoft\ Word\ Document* ]]; then
     if cmd_exist antiword; then
       msg "append $sep to filename to view the raw word document"

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -1027,7 +1027,7 @@ isfinal() {
 #ifdef wvText
   elif [[ "$1" = *Microsoft\ Word\ Document* ]] && cmd_exist wvText; then
     msg "append $sep to filename to view the raw word document"
-    wvText "$2" -
+    wvText "$2" /dev/stdout
 #ifdef antiword
   elif [[ "$1" = *Microsoft\ Word\ Document* ]]; then
     if cmd_exist antiword; then


### PR DESCRIPTION
wvText is a script that uses > "${2}" shell redirection to point to its
output file. Its shebang is /bin/sh, which is often a symlink to bash,
which does not reinterpret > - as going to stdout.

But random people on the internet seem to be saying that while
/dev/stdout is not universal (not POSIX, and absent on e.g. MinGW and
AIX), bash knows to emulate it when it's passed as a command line
parameter:

https://unix.stackexchange.com/questions/36403/

So I'm blindly guessing that this improves the chances of correctly
handling a Word doc where abiword is installed (which pulls in wvText,
which is the first Word preprocessor attempted).