### PR TITLE
add syntax highlighting for shell scripts

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -684,9 +684,9 @@ isfinal() {
     msg "append $sep to filename to view the perl source"
     istemp perldoc "$2"
   elif [[ "$1" = *\ script* ]]; then
-    cat "$2"
+    set "plain text" "$2"
   elif [[ "$1" = *text\ executable* ]]; then
-    cat "$2"
+    set "plain text" "$2"
   elif [[ "$1" = *PostScript$NOL_A_P* ]]; then
     if cmd_exist pstotext; then
       msg "append $sep to filename to view the postscript file"

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -802,9 +802,9 @@ isfinal() {
     istemp perldoc "$2"
 #endif
   elif [[ "$1" = *\ script* ]]; then
-    cat "$2"
+    set "plain text" "$2"
   elif [[ "$1" = *text\ executable* ]]; then
-    cat "$2"
+    set "plain text" "$2"
 #ifdef pstotext
   elif [[ "$1" = *PostScript$NOL_A_P* ]]; then
     if cmd_exist pstotext; then


### PR DESCRIPTION
Shell script executables were considered already plain text, which is correct; with this change, syntax highlighting is also enabled