### PR TITLE
Maintenance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # This is a generated file, do not edit it. Use configure to modify it
 PREFIX = /usr/local
-MODE = --yes
+MODE = --default
 
 .PHONY: install
 

--- a/README
+++ b/README
@@ -474,7 +474,7 @@ less diagram.png
  lzip                 http://download.savannah.gnu.org/releases/lzip/
  dvi2tty              http://www.ctan.org/tex-archive/dviware/dvi2tty/
  unrtf                http://ftp.gnu.org/gnu/unrtf/
- docx2txt.pl          https://github.com/arthursucks/docx2txt
+ docx2txt             https://github.com/arthursucks/docx2txt
  pandoc               http://pandoc.org
  libreoffice          http://www.libreoffice.org
  odt2txt              https://github.com/dstosberg/odt2txt

--- a/README
+++ b/README
@@ -233,7 +233,7 @@ Contents
  iso images	requires isoinfo
  MacOSX archive	requires lsbom
  MacOS X bom	requires lsbom
- MacOS X plist	requires plisutil
+ MacOS X plist	requires plistutil
  cab		requires cabextract (version 1.0 or above)
  gpg encrypted	requires gpg
  perl storable	requires perl (and the perl modules Storable and Data::Dumper)

--- a/README
+++ b/README
@@ -233,7 +233,7 @@ Contents
  iso images	requires isoinfo
  MacOSX archive	requires lsbom
  MacOS X bom	requires lsbom
- MacOS X plist	requires plutil
+ MacOS X plist	requires plisutil
  cab		requires cabextract (version 1.0 or above)
  gpg encrypted	requires gpg
  perl storable	requires perl (and the perl modules Storable and Data::Dumper)

--- a/code2color
+++ b/code2color
@@ -33,32 +33,32 @@ if ( $ARGV[0] =~ /^\d+$/  and $ARGV[1] ) {
       $psargs = '-f';
     }
     eval "use Proc::ProcessTable $procvers";
-    if ( $@ ) { 
+    if ( $@ ) {
       my $p = `ps -p $PPID $psargs`;
       exit 1 if $p =~ /\bless\s+/ and $p !~ /less\s+-\w*r\w*\b/is;
       if ( $p !~ /\bless\s+/ ) {
-	if ($p =~ /\d+\s+(\d+)/) {
-	  $PPID = $1;
-	} else {
-	  $PPID = $1 if $p =~ /(\d+)/;
-	}
-	my $p2 = `ps -p $PPID $psargs`;
-	exit 1 if $p2 !~ /less\s+-\w*r\w*\b/is;
+        if ($p =~ /\d+\s+(\d+)/) {
+          $PPID = $1;
+        } else {
+          $PPID = $1 if $p =~ /(\d+)/;
+        }
+        my $p2 = `ps -p $PPID $psargs`;
+        exit 1 if $p2 !~ /less\s+-\w*r\w*\b/is;
       }
     } else {
       my $pt = new Proc::ProcessTable;
       for (@{$pt->table}) {
-	next unless $_->pid eq $PPID;
-	$p = $_->cmndline;
-	exit 1 if $p =~ /\bless\s+/ and $p !~ /less\s+-\w*r\w*\b/i;
-	if ( $p !~ /\bless\s+/ ) {
-	  $PPID = $_->ppid;
-	  for (@{$pt->table}) {
-	    next unless $_->pid eq $PPID;
-	    $p = $_->cmndline;
-	    exit 1 if $p !~ /less\s+-\w*r\w*\b/i;
-	  }
-	}
+        next unless $_->pid eq $PPID;
+        $p = $_->cmndline;
+        exit 1 if $p =~ /\bless\s+/ and $p !~ /less\s+-\w*r\w*\b/i;
+        if ( $p !~ /\bless\s+/ ) {
+          $PPID = $_->ppid;
+          for (@{$pt->table}) {
+            next unless $_->pid eq $PPID;
+            $p = $_->cmndline;
+            exit 1 if $p !~ /less\s+-\w*r\w*\b/i;
+          }
+        }
       }
     }
   }
@@ -156,34 +156,34 @@ sub main {
     # undefine the input record separator so everything gets loaded in one turn
     local $/ = undef;  # don't propogate this change outside this package.
 
-    # Only set %STYLESHEET and %LANGUAGE if they haven't been 
-    # already set in a previous call ( if, say, we're running 
-    # in a persistent environment under mod_perl) 
+    # Only set %STYLESHEET and %LANGUAGE if they haven't been
+    # already set in a previous call ( if, say, we're running
+    # in a persistent environment under mod_perl)
     # or if the langfile is passed in explicitly.
     if ( $params{'langfile'} or ! $STYLE_AND_LANGUAGE_FLAG ) {
       $STYLE_AND_LANGUAGE_FLAG = 1;  # now they will be defined.
-      
+
       print STDERR "getting patterns...\n"  if ($params{'verbose'});
       # building up the database
       # newer entries overwrite old ones
       my @CONFIG_FILES;
       push @CONFIG_FILES, "/etc/code2html.config";
-      push @CONFIG_FILES, 
+      push @CONFIG_FILES,
         $ENV{'HOME'}."/.code2html.config"   if $ENV{'HOME'};
-      push @CONFIG_FILES, 
+      push @CONFIG_FILES,
         split(/:/,$ENV{'CODE2HTML_CONFIG'}) if $ENV{'CODE2HTML_CONFIG'};
-      push @CONFIG_FILES, 
+      push @CONFIG_FILES,
         split(/:/,$params{'langfile'})      if $params{'langfile'};
-      
-      %STYLESHEET = %{ &get_default_stylesheet } ; 
-      %LANGUAGE   = %{ &get_default_database   } ; 
+
+      %STYLESHEET = %{ &get_default_stylesheet } ;
+      %LANGUAGE   = %{ &get_default_database   } ;
 
       for (@CONFIG_FILES) {
         if ( -r $_){
-          # if I use `do $_` instead of scalar eval... 
-          #  %LANGUAGE is not exported and imported correctly 
+          # if I use `do $_` instead of scalar eval...
+          #  %LANGUAGE is not exported and imported correctly
           # (read: at all) (PP)
-          unless (scalar eval `cat $_`) {     
+          unless (scalar eval `cat $_`) {
             warn "couldn't parse $_: $@" if $@;
           };
         };
@@ -192,29 +192,29 @@ sub main {
 
     # set outputformat
     #   When called as a package, "die" is impolite. Changed to "return".
-    # die "Outputformat $params{'outputformat'} not defined" 
+    # die "Outputformat $params{'outputformat'} not defined"
     # unless defined $STYLESHEET{$params{'outputformat'}};
-    return "Outputformat $params{'outputformat'} not defined" 
+    return "Outputformat $params{'outputformat'} not defined"
       unless defined $STYLESHEET{$params{'outputformat'}};
 
     my %STYLE = % { $STYLESHEET{$params{'outputformat'}} };
-      
+
     # load alternate template if given
     if (($params{'template'} ne "") && ( ! $params{'noheader'} )) {
-#         open (FILE, $params{'template'}) || 
+#         open (FILE, $params{'template'}) ||
 #           die ("Could not open template file $params{'template'}: $!");
-      open (FILE, $params{'template'}) || 
+      open (FILE, $params{'template'}) ||
         return ("Could not open template file $params{'template'}: $!");
       $STYLE{'template'} = <FILE>;
       close (FILE);
     };
 
-    # set up the global ENTITIES variables ( the scalar and the hash ) 
+    # set up the global ENTITIES variables ( the scalar and the hash )
     # from the STYLE definition
     $ENTITIES =     $ { $STYLE{'entities'} }{'listofchars'};
     %ENTITIES = % { $ { $STYLE{'entities'} }{'replace_by' } };
 
-    # modify the header and footer so that the template variables 
+    # modify the header and footer so that the template variables
     # are set correcly
 
     unless ($STYLE{'template'} =~ /^(.*)%%code%%(.*)$/s) {
@@ -228,24 +228,24 @@ sub main {
     $STYLE{'header'} =~ s/%%version%%/$vernr/g;
     $STYLE{'footer'} =~ s/%%version%%/$vernr/g;
 
-    # load the input file and set params{'langmode'} 
+    # load the input file and set params{'langmode'}
     # if it is not already. this is done by probing a
     # set of rules defined in %LANGUAGE
     my $code_ref;
     print STDERR "loading input file...\n"    if ($params{'verbose'});
-    $code_ref = &get_input_file(\%params, 
-                                \%LANGUAGE, 
-                                $params{'langmode'}, 
+    $code_ref = &get_input_file(\%params,
+                                \%LANGUAGE,
+                                $params{'langmode'},
                                 $params{'alt_langmode'});
 
     return 0 if ! ref $code_ref;
     # select the rules for out language.
-    my $language_rules_ref = 
+    my $language_rules_ref =
       $LANGUAGE{ lc($params{'langmode'}) }->{'patterns'};
 
     print STDERR "applying stylesheet...\n"      if ($params{'verbose'});
     # Apply the Stylesheets
-    # set 'starttag' and 'endtag' for every rule according to 
+    # set 'starttag' and 'endtag' for every rule according to
     # its 'style' value the tags are defined in the stylesheet
     &apply_stylesheets_to_rules( $language_rules_ref, \%STYLE );
 
@@ -254,7 +254,7 @@ sub main {
 
     my $snippetlist_ref = [] ;
     print STDERR "creating snippet-list...\n"    if $params{'verbose'};
-    &create_snippetlist( $language_rules_ref, 
+    &create_snippetlist( $language_rules_ref,
                          $$code_ref, $snippetlist_ref, \%STYLE);
 
     print STDERR "getting html converted code ...\n"  if $params{'verbose'};
@@ -277,7 +277,7 @@ sub main {
         print $html;
       }
       else {
-        open(FILEHANDLE, '>'.$params{outfile}) or 
+        open(FILEHANDLE, '>'.$params{outfile}) or
           return( " Couldn't open output file " . $params{outfile} . "$!");
 
         print FILEHANDLE $html;
@@ -331,7 +331,7 @@ sub parse_passed_params {
                );
   $RESULT{title} = $RESULT{infile} if $RESULT{infile} && !$RESULT{title};
   $RESULT{title} = 'Code2HTML' unless $RESULT{title};
-  if ( $RESULT{linenumbers} and 
+  if ( $RESULT{linenumbers} and
        $RESULT{linenumbers} !~ m/^none|normal|linked$/ ) {
     $RESULT{linenumbers} = 'normal';
   };
@@ -345,7 +345,7 @@ sub parse_passed_params {
 sub checkTabulator
 {
     my ($line, $TABSTOP) = @_;
-    
+
     while ((my $at = index($line, "\t")) != -1)
       {
           my $cnt = ($TABSTOP - ($at % $TABSTOP));
@@ -367,7 +367,7 @@ sub get_input_file
     # in/out : $langmode;
     # in/out : $alt_langmode;
     # returns: input file
-    
+
       my %PARAMS       = %{$_[0]};
       my %LANGUAGE     = %{$_[1]};
       my $langmode     = $_[2];
@@ -381,18 +381,18 @@ sub get_input_file
         }
       else
         {
-	    if ($PARAMS{'infile'} eq '-') {
-		*FILEHANDLE = *STDIN;
-	    } else {
-                open(FILEHANDLE, $PARAMS{'infile'}) 
+            if ($PARAMS{'infile'} eq '-') {
+                *FILEHANDLE = *STDIN;
+            } else {
+                open(FILEHANDLE, $PARAMS{'infile'})
                 || return("While opening '$PARAMS{'infile'}' for input: ".$!."\n");
-	    }
-	    local $/=undef;
+            }
+            local $/=undef;
             $code = <FILEHANDLE>;
             close(FILEHANDLE);
-	    $PARAMS{'infile'} = $opt_i || $PARAMS{'infile'};
+            $PARAMS{'infile'} = $opt_i || $PARAMS{'infile'};
         };
-      
+
       if ($PARAMS{'replacetabs'} != 0)
         {
             $code = join (
@@ -403,9 +403,9 @@ sub get_input_file
                           my @dummy = split(/\n/, $code)
                          );
         };
-      
 
-      
+
+
       if ( not $langmode )
         {
             my $test_code = substr($code, 0, $LANG_TEST_LENGTH);
@@ -415,11 +415,11 @@ sub get_input_file
 
             for (keys %LANGUAGE)
               {
-                  if (  (($LANGUAGE{$_}->{'filename'} ne '') 
-                         && ($PARAMS{'infile'} 
+                  if (  (($LANGUAGE{$_}->{'filename'} ne '')
+                         && ($PARAMS{'infile'}
                              =~  m/$LANGUAGE{$_}->{filename}/))  ||
-                        (($LANGUAGE{$_}->{'regex'}    ne '') 
-                         && ($test_code  =~  m/$LANGUAGE{$_}->{regex}/   ))   
+                        (($LANGUAGE{$_}->{'regex'}    ne '')
+                         && ($test_code  =~  m/$LANGUAGE{$_}->{regex}/   ))
                      )
                     {
                         $langmode = $_;
@@ -431,7 +431,7 @@ sub get_input_file
               {
                   if ( not $alt_langmode )
                     {
-                      warn("Guessing language mode failed. " . 
+                      warn("Guessing language mode failed. " .
                            "Using fallback mode: '$alt_langmode'\n");
                       $langmode = $alt_langmode;
                       $alt_langmode = '';
@@ -447,7 +447,7 @@ sub get_input_file
                   # warn("using '$langmode'\n");
               };
         };
-      
+
       $_[2] = $langmode;
       $_[3] = $alt_langmode;
       print "==> append : to filename to switch off syntax highlighting\n"
@@ -460,8 +460,8 @@ sub get_input_file
 ####################### put_headers #######################################
 ###########################################################################
 sub put_headers
-{       
-      my $html;    
+{
+      my $html;
       my %PARAMS = %{shift()};
       my $STYLE_REF = shift();
 
@@ -509,16 +509,16 @@ sub create_snippetlist
     ## FWIW, I pronounce '@res' REEZE, as in the plural of '$re'.
     ##
     my @res ;
-    
+
     my $pos ;
-    
+
     for ( @$regexps_ref ) {
         pos( $code ) = 0 ;
 #++$m ;
         next unless $code =~ m/($_->{regex})/gms ;
 
         $pos = pos( $code ) ;
-#       $res[@res] = [ 
+#       $res[@res] = [
 #                     $_->{regex},
 #                     $ { $ { $$style_ref{'tags'} } { $_->{style} } } { 'start' },
 #                     $ { $ { $$style_ref{'tags'} } { $_->{style} } } { 'stop' },
@@ -527,7 +527,7 @@ sub create_snippetlist
 #                     $pos,
 #                     scalar( @res ),
 #                    ] ;
-        $res[@res] = [ 
+        $res[@res] = [
                       $_->{regex},
                       $_->{starttag},
                       $_->{endtag},
@@ -537,11 +537,11 @@ sub create_snippetlist
                       scalar( @res ),
                      ] ;
     }
-    
+
     ## 90% of all child regexes end up with 0 or 1 regex that needs to be
     ## worried about. Trimming out the 0's speeds things up a bit and
     ## makes the below loop simpler, since there's always at least
-    ## 1 regexp.  It donsn't speed things up much by itself: the percentage 
+    ## 1 regexp.  It donsn't speed things up much by itself: the percentage
     ## of times this fires is really small.  But it does simplify the loop
     ## below and speed it up.
     unless ( @res ) {
@@ -549,9 +549,9 @@ sub create_snippetlist
         push @$snippetlist_ref, $code ;
         return ;
     }
-    
+
     @res = sort { $a->[4] <=> $b->[4] || $a->[6] <=> $b->[6] } @res ;
-    
+
     ## Add a dummy at the end, which makes the logic below simpler / faster.
     $res[@res] = [
                   undef,
@@ -562,7 +562,7 @@ sub create_snippetlist
                   $length,
                   scalar( @res ),
                  ] ;
-    
+
     ## These are declared here for (minor) speed improvement.
     my $re ;
     my $match_spos ;
@@ -575,7 +575,7 @@ sub create_snippetlist
     my $rest ;
     my $i ;
     my $l ;
-    
+
 my @changed_res ;
 my $j ;
 
@@ -583,16 +583,16 @@ my $j ;
 MAIN:
     while ( $pos < $length ) {
         $re = $res[0] ;
-        
+
         $match_spos = $re->[4] ;
         $match_pos  = $re->[5] ;
-        
+
         if ( $match_spos > $pos ) {
             $prefix  = substr( $code, $pos, $match_spos - $pos ) ;
             $prefix  =~ s/($ENTITIES)/$ENTITIES{$1}/ge ;
             push @$snippetlist_ref, $prefix ;
         }
-        
+
         if ( $match_pos > $match_spos ) {
             $snippet = substr( $code, $match_spos, $match_pos - $match_spos ) ;
             if ( @{$re->[3]} ) {
@@ -605,9 +605,9 @@ MAIN:
                 push @$snippetlist_ref, $re->[1], $snippet, $re->[2];
             }
         }
-        
+
         $pos = $match_pos ;
-        
+
         ##
         ## Hand coded optimizations.  Luckily, the cases that arise most often
         ## are the easiest to tune.
@@ -636,9 +636,9 @@ MAIN:
             else {
                 $re->[5] = $re_pos  = pos( $code ) ;
                 $re->[4] = $re_spos = $re_pos - length( $1 ) ;
-                
+
                 ## Walk down the array looking for $re's new home.
-                ## The first few loop iterations are unrolled and done manually 
+                ## The first few loop iterations are unrolled and done manually
                 ## for speed, which handles 85 to 90% of the cases where only
                 ## $re needs to be moved.
                 ##
@@ -652,7 +652,7 @@ MAIN:
                 $re_num = $re->[6] ;
                 if ( ( $re_spos <=> $res[1]->[4] || $re_num <=> $res[1]->[6] ) <= 0 ) {
 #++$o{'1'} ;
-                    next 
+                    next
                 }
                 $res[0] = $res[1] ;
 
@@ -662,21 +662,21 @@ MAIN:
                     next ;
                 }
                 $res[1] = $res[2] ;
-                
+
                 if ( ( $re_spos <=> $res[3]->[4] || $re_num <=> $res[3]->[6] ) <= 0 ) {
 #++$o{'3'} ;
                     $res[2] = $re ;
                     next ;
                 }
                 $res[2] = $res[3] ;
-                
+
                 if ( ( $re_spos <=> $res[4]->[4] || $re_num <=> $res[4]->[6] ) <= 0 ) {
 #++$o{'3'} ;
                     $res[3] = $re ;
                     next ;
                 }
                 $res[3] = $res[4] ;
-                
+
                 if ( ( $re_spos <=> $res[5]->[4] || $re_num <=> $res[5]->[6] ) <= 0 ) {
 #++$o{'4'} ;
                     $res[4] = $re ;
@@ -689,7 +689,7 @@ MAIN:
                 $l = $#res ;
                 for ( ; $i < $l ; ++$i ) {
                     last
-                      if ( 
+                      if (
                           ( $re_spos <=> $res[$i]->[4] || $re_num <=> $res[$i]->[6] )
                           <= 0
                          ) ;
@@ -698,10 +698,10 @@ MAIN:
 #++$p{sprintf( "%2d", $i )} ;
                 $res[$i-1] = $re ;
             }
-            
+
             next ;
         }
-        
+
 # =cut
 
         ##
@@ -734,7 +734,7 @@ MAIN:
             @changed_res = ( $re ) ;
             $i = 1 ;
         }
-        
+
         ## If the optimizations above are in, the second one always
         ## needs to be tweaked, too.
         $re = $res[$i] ;
@@ -755,7 +755,7 @@ MAIN:
             $re->[5] = $re_pos  = pos( $code ) ;
             $re->[4] = $re_spos = $re_pos - length( $1 ) ;
             if ( @changed_res &&
-                 ( $changed_res[0]->[4] <=> $re_spos || 
+                 ( $changed_res[0]->[4] <=> $re_spos ||
                    $changed_res[0]->[6] <=> $re->[6]
                  ) > 0
                ) {
@@ -766,7 +766,7 @@ MAIN:
             }
             ++$i ;
         }
-        
+
         for ( ; ; ++$i ) {
             local $_ = $res[$i] ;
 #++$m ;
@@ -789,17 +789,17 @@ MAIN:
 
             $_->[5] = $re_pos  = pos( $code ) ;
             $_->[4] = $re_spos = $re_pos - length( $1 ) ;
-            
+
             ## Insertion sort in to @changed_res
             $re_num = $_->[6] ;
             for ( $j = $#changed_res ; $j > -1 ; --$j ) {
                 last
-                  if ( 
-                      ( $changed_res[$j]->[4] <=> $re_spos || 
-                        $changed_res[$j]->[6] <=> $re_num 
+                  if (
+                      ( $changed_res[$j]->[4] <=> $re_spos ||
+                        $changed_res[$j]->[6] <=> $re_num
                       ) < 0
                      ) ;
-                $changed_res[$j+1] = $changed_res[$j] ; 
+                $changed_res[$j+1] = $changed_res[$j] ;
             }
             $changed_res[$j+1] = $_ ;
         }
@@ -829,16 +829,16 @@ sub put_output {
 
     my $result;
 
-    my $prefix = ''; 
-    $prefix = $params->{'line_number_prefix'}.'_'  
+    my $prefix = '';
+    $prefix = $params->{'line_number_prefix'}.'_'
       if $params->{'line_number_prefix'};
 
-    $result = &{ $ { $$STYLE_REF{'linenumbers'}} {$params->{'linenumbers'}} 
+    $result = &{ $ { $$STYLE_REF{'linenumbers'}} {$params->{'linenumbers'}}
                }(join ('', @$snippetlist_ref), $prefix);
 
     # print FILEHANDLE $result unless $params->{'dont_print_output'} ;
     # print FILEHANDLE $$STYLE_REF{'footer'}  unless $params->{'noheader'};
-    
+
     $result .= $$STYLE_REF{'footer'} unless $params->{noheader};
 
     return $result;
@@ -855,8 +855,8 @@ my %STYLESHEET;
 
 
 ##########
-########## different color modes for html. 
-# those are named html-dark, html-nobc and html-light. 
+########## different color modes for html.
+# those are named html-dark, html-nobc and html-light.
 # html-light is also named html
 # the only difference between html-light and html-nobc is
 # that html-light defines a body background and text color.
@@ -891,10 +891,10 @@ if ($@) {
 $STYLESHEET{'xterm'} =  { 'template'       => '%%code%%',
                          'content-type' => 'text/html',
                          'linenumbers'  => {
-                                            'none'          => sub { 
+                                            'none'          => sub {
                                                                     return $_[0];
                                                                    },
-                                            'normal'        => sub { 
+                                            'normal'        => sub {
                                                                    # o as the first parameter is the joined snippetlist
                                                                    # o the second is an optional prefix, needed if more than one block
                                                                    #   in a file is highlighted. needed in patch-mode. may be empty
@@ -905,12 +905,12 @@ $STYLESHEET{'xterm'} =  { 'template'       => '%%code%%',
                                                                    my $format = qq{%${lengthofnr}u %s\n} ;
                                                                    join ('', map (  {$nr++; sprintf ( $format , $nr, $_ )} @lines));
                                                                    },
-                                             'linked'       => sub { 
+                                             'linked'       => sub {
                                                                    # is not defined for xterm output, therefore do nothing
                                                                     return $_[0];
                                                                    },
                                            },
-                         'tags'         => { 
+                         'tags'         => {
                                             'comment'                => { 'start' => $blue,
                                                                           'stop'  => $reset },
                                             'doc comment'            => { 'start' => "$bold$blue",
@@ -998,8 +998,8 @@ $STYLESHEET{'html-light'} =  { 'template'       =>
 <pre>
 %%code%%
 </pre>
-<p align=right><small><font color=gray>syntax highlighted by 
-<a href="http://www.palfrader.org/code2html"><font 
+<p align=right><small><font color=gray>syntax highlighted by
+<a href="http://www.palfrader.org/code2html"><font
 color=gray>Code2HTML</font></a>, v. %%version%%</font></small></p>
 </body>
 </html>
@@ -1014,10 +1014,10 @@ color=gray>Code2HTML</font></a>, v. %%version%%</font></small></p>
                                                               }
                                            },
                          'linenumbers'  => {
-                                            'none'          => sub { 
+                                            'none'          => sub {
                                                                     return $_[0];
                                                                    },
-                                            'normal'        => sub { 
+                                            'normal'        => sub {
                                                                    # o as the first parameter is the joined snippetlist
                                                                    # o the second is an optional prefix, needed if more than one block
                                                                    #   in a file is highlighted. needed in patch-mode. may be empty
@@ -1029,18 +1029,18 @@ color=gray>Code2HTML</font></a>, v. %%version%%</font></small></p>
                                                                    my $format = qq{<a name="$_[1]line%u">%${lengthofnr}u</a> %s\n} ;
                                                                    join ('', map (  {$nr++; sprintf ( $format , $nr, $nr, $_ )} @lines));
                                                                    },
-                                             'linked'       => sub { 
+                                             'linked'       => sub {
                                                                    # this should do the same as above only with linenumbers that link to themselves
                                                                    # If this style does not support this, use the same as above.
                                                                    my @lines = split ( /\n/, $_[0] );
 
-                                                                   my $nr = 0; 
+                                                                   my $nr = 0;
                                                                    my $lengthofnr = length(@lines);
                                                                    my $format = qq{<a name="$_[1]line%u" href="#$_[1]line%u">%$ {lengthofnr}u</a> %s\n};
                                                                    join ('', map (  {$nr++; sprintf ( $format , $nr, $nr, $nr, $_ )} @lines));
                                                                    }
                                            },
-                         'tags'         => { 
+                         'tags'         => {
                                             'comment'                => { 'start' => '<font color="#444444">',
                                                                           'stop'  => '</font>' },
                                             'doc comment'            => { 'start' => '<font color="#444444"><i>',
@@ -1055,27 +1055,27 @@ color=gray>Code2HTML</font></a>, v. %%version%%</font></small></p>
                                                                           'stop'  => '</font>' },
                                             'numeric'                => { 'start' => '<font color="#FF0000">',
                                                                           'stop'  => '</font>' },
-                                            
+
                                             'identifier'             => { 'start' => '<font color="#2040a0">',
                                                                           'stop'  => '</font>' },
                                             'predefined identifier'  => { 'start' => '<font color="#2040a0"><strong>',
                                                                           'stop'  => '</strong></font>' },
-                                     
+
                                             'type'                   => { 'start' => '<font color="#2040a0"><strong>',
                                                                           'stop'  => '</strong></font>' },
                                             'predefined type'        => { 'start' => '<font color="#2040a0"><strong>',
                                                                           'stop'  => '</strong></font>' },
-                                            
+
                                             'reserved word'          => { 'start' => '<strong>',
                                                                           'stop'  => '</strong>' },
                                             'library function'       => { 'start' => '<font color="a52a2a"><strong>',
                                                                           'stop'  => '</strong></font>' },
-                                            
+
                                             'include'                => { 'start' => '<font color="0000ff"><strong>',
                                                                           'stop'  => '</strong></font>' },
                                             'preprocessor'           => { 'start' => '<font color="0000ff"><strong>',
                                                                           'stop'  => '</strong></font>' },
-                                            
+
                                             'braces'                 => { 'start' => '<font color="4444FF"><strong>',
                                                                           'stop'  => '</strong></font>' },
                                             'symbol'                 => { 'start' => '<font color="4444FF">',
@@ -1087,10 +1087,10 @@ color=gray>Code2HTML</font></a>, v. %%version%%</font></small></p>
                                                                           'stop'  => '</font>' },
                                             'function header args'   => { 'start' => '<font color="2040a0">',
                                                                           'stop'  => '</font>' },
-                                            
+
                                             'regex'                  => { 'start' => '<font color="b000d0">',
                                                                           'stop'  => '</font>' },
-                                            
+
                                             'text'                   => { 'start' => '<i>',
                                                                           'stop'  => '</i>'},
 
@@ -1136,8 +1136,8 @@ ${ $STYLESHEET{'html-nobg'}} {'template'} = '<html>
 <pre>
 %%code%%
 </pre>
-<p align=right><small><font color=gray>syntax highlighted by 
-<a href="http://www.palfrader.org/code2html"><font 
+<p align=right><small><font color=gray>syntax highlighted by
+<a href="http://www.palfrader.org/code2html"><font
 color=gray>Code2HTML</font></a>, v. %%version%%</font></small></p>
 </body>
 </html>
@@ -1145,7 +1145,7 @@ color=gray>Code2HTML</font></a>, v. %%version%%</font></small></p>
 
 
 # html-dark is a modification of html-light
-# in such a way, that the body tag does define 
+# in such a way, that the body tag does define
 # different colors and that the <font> colors are different.
 
 %{$STYLESHEET{'html-dark'}} = %{$STYLESHEET{'html-light'}};
@@ -1157,8 +1157,8 @@ ${ $STYLESHEET{'html-dark'}} {'template'} = '<html>
 <pre>
 %%code%%
 </pre>
-<p align=right><small><font color=gray>syntax highlighted by 
-<a href="http://www.palfrader.org/code2html"><font 
+<p align=right><small><font color=gray>syntax highlighted by
+<a href="http://www.palfrader.org/code2html"><font
 color=gray>Code2HTML</font></a>, v. %%version%%</font></small></p>
 </body>
 </html>
@@ -1178,27 +1178,27 @@ ${ $STYLESHEET{'html-dark'}} {'tags'} = {
                                                                           'stop'  => '</font>' },
                                             'numeric'                => { 'start' => '<font color="#FF0000">',
                                                                           'stop'  => '</font>' },
-                                           
+
                                             'identifier'             => { 'start' => '<font color="#B0B0B0">',
                                                                           'stop'  => '</font>' },
                                             'predefined identifier'  => { 'start' => '<font color="#2040a0"><strong>',
                                                                           'stop'  => '</strong></font>' },
-                                     
+
                                             'type'                   => { 'start' => '<font color="#2040a0"><strong>',
                                                                           'stop'  => '</strong></font>' },
                                             'predefined type'        => { 'start' => '<font color="#2040a0"><strong>',
                                                                           'stop'  => '</strong></font>' },
-                                            
+
                                             'reserved word'          => { 'start' => '<strong>',
                                                                           'stop'  => '</strong>' },
                                             'library function'       => { 'start' => '<font color="a52a2a"><strong>',
                                                                           'stop'  => '</strong></font>' },
-                                            
+
                                             'include'                => { 'start' => '<font color="#00FF00">',
                                                                           'stop'  => '</font>' },
                                             'preprocessor'           => { 'start' => '<font color="#00FF00">',
                                                                           'stop'  => '</font>' },
-                                            
+
                                             'braces'                 => { 'start' => '<font color="darkCyan"><strong>',
                                                                           'stop'  => '</strong></font>' },
                                             'symbol'                 => { 'start' => '<font color="darkCyan">',
@@ -1210,10 +1210,10 @@ ${ $STYLESHEET{'html-dark'}} {'tags'} = {
                                                                           'stop'  => '</font>' },
                                             'function header args'   => { 'start' => '<font color="2040a0">',
                                                                           'stop'  => '</font>' },
-                                            
+
                                             'regex'                  => { 'start' => '<font color="b000d0">',
                                                                           'stop'  => '</font>' },
-                                            
+
                                             'text'                   => { 'start' => '<i>',
                                                                           'stop'  => '</i>'},
 
@@ -1261,8 +1261,8 @@ $LANGUAGE{'plain'}      = {
                             'regex'      => '',
                             'patterns'   => []
                           };
- 
- 
+
+
 
 
 
@@ -1477,21 +1477,21 @@ $LANGUAGE{'awk'}       =  {
                                               }
                                             ]
                            };
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 # taken from nedit
 # modified by PP
 $LANGUAGE{'c'}          = {
@@ -1565,7 +1565,7 @@ $LANGUAGE{'c'}          = {
                                                                   {
                                                                     'name'       => 'esc character',
                                                                     'regex'      => '\\\\.',
-                                                                    'style'      => 'esc character', 
+                                                                    'style'      => 'esc character',
                                                                     'childregex' => []
                                                                   }
                                                                 ]
@@ -1600,7 +1600,7 @@ $LANGUAGE{'c'}          = {
                                                 'style'      => 'symbol',
                                                 'childregex' => []
                                               },
-                                              { 
+                                              {
                                                 'name'       => 'identifiers',
                                                 'regex'      => '([a-zA-Z_][a-zA-Z_0-9]*)',
                                                 'style'      => 'identifier',
@@ -1608,21 +1608,21 @@ $LANGUAGE{'c'}          = {
                                               }
                                             ]
                           };
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 # taken from nedit
 # modified by PP
 $LANGUAGE{'c++'}        = {
@@ -1772,36 +1772,36 @@ $LANGUAGE{'gpasm'}      = {
                                               {
                                                 'name'       => 'args',
                                                 'regex'      => '^.*$',
-					        'style'      => 'symbol',
+                                                'style'      => 'symbol',
                                                 'childregex' => [
-						 {
-						     'name'       => 'comment',
-						     'regex'      => ';.*?$',
-					             'style'      => 'comment',
+                                                 {
+                                                     'name'       => 'comment',
+                                                     'regex'      => ';.*?$',
+                                                     'style'      => 'comment',
                                                      'childregex' => []
                                                  },
                                                  {
                                                      'name'       => 'labels',
                                                      'regex'      => '^[A-Za-z_][A-Za-z_0-9]*:?',
-					             'style'      => 'identifier',
+                                                     'style'      => 'identifier',
                                                      'childregex' => []
                                                  },
 
                                                  {
                                                      'name'       => 'menonics',
                                                      'regex'      => '^[ \t]+[A-Za-z_][A-Za-z_0-9]*',
-					             'style'      => 'reserved word',
+                                                     'style'      => 'reserved word',
                                                      'childregex' => []
                                                  },
                                               {
                                                 'name'       => 'string',
                                                 'regex'      => '""|".*?([^\\\\](\\\\\\\\)*)"|"\\\\\\\\"',
-					        'style'      => 'string',
+                                                'style'      => 'string',
                                                 'childregex' => [
                                                                   {
                                                                     'name'       => 'esc character',
                                                                     'regex'      => '\\\\.',
-					                            'style'      => 'esc character',
+                                                                    'style'      => 'esc character',
                                                                     'childregex' => []
                                                                   }
                                                                 ]
@@ -1833,7 +1833,6 @@ $LANGUAGE{'groff'}      = {
                                               }
                                             ]
                           };
- 
 
 
 
@@ -1845,9 +1844,10 @@ $LANGUAGE{'groff'}      = {
 
 
 
- 
- 
- 
+
+
+
+
 # taken from nedit
 # modified by PP
 $LANGUAGE{'html'}       = {
@@ -1900,9 +1900,9 @@ $LANGUAGE{'html'}       = {
                                             ]
                        };
 
- 
- 
-# Added May 17, 2002, Jim M. 
+
+
+# Added May 17, 2002, Jim M.
 $LANGUAGE{'xml'}       = {
                             'filename'   => '(?i)\\.(xml|xps|xsl|axp|ppd)?$',
                             'regex'      => '',
@@ -1952,7 +1952,6 @@ $LANGUAGE{'xml'}       = {
                                               }
                                             ]
                        };
- 
 
 
 
@@ -1965,8 +1964,9 @@ $LANGUAGE{'xml'}       = {
 
 
 
- 
- 
+
+
+
 # taken from nedit
 # modified by PP
 $LANGUAGE{'java'}       = {
@@ -2069,20 +2069,20 @@ $LANGUAGE{'java'}       = {
                                               }
                                             ]
                           };
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 # taken from nedit
 # modified by PP
 $LANGUAGE{'javascript'} = {
@@ -2143,7 +2143,7 @@ $LANGUAGE{'javascript'} = {
                                                                     'childregex' => []
                                                                   }
                                                                 ]
-                                              },  
+                                              },
                                               {
                                                 'name'       => 'built in object type',
                                                 'regex'      => '\\b(anchor|Applet|Area|Array|button|checkbox|Date|document|elements|FileUpload|form|frame|Function|hidden|history|Image|link|location|Math|navigator|Option|password|Plugin|radio|reset|select|string|submit|text|textarea|window)\\b',
@@ -2216,7 +2216,7 @@ $LANGUAGE{'js'}         = $LANGUAGE{'javascript'};
 
 $LANGUAGE{'lisp'}       = {
                             'filename' => '\\.(lsp|l)$',
-			    'regex' => '',
+                            'regex' => '',
                             'patterns' => [
                                {
                                  'name'       => 'parens',
@@ -2506,20 +2506,20 @@ $LANGUAGE{'pas'}        = {
                           };
 $LANGUAGE{'pascal'}     = $LANGUAGE{'pas'};
 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 # taken from nedit
 # modified by PP
 # modified by BS
@@ -2664,7 +2664,7 @@ $LANGUAGE{'perl'}       = {
                                               }
                                             ]
                           };
- 
+
 
 
 
@@ -2763,7 +2763,7 @@ $LANGUAGE{'pov'}        = {
                                                                   {
                                                                     'name'       => 'esc character',
                                                                     'regex'      => '\\\\.',
-                                                                    'style'      => 'esc character', 
+                                                                    'style'      => 'esc character',
                                                                     'childregex' => []
                                                                   }
                                                                 ]
@@ -2792,7 +2792,7 @@ $LANGUAGE{'pov'}        = {
                                                 'style'      => 'symbol',
                                                 'childregex' => []
                                               },
-                                              { 
+                                              {
                                                 'name'       => 'identifiers',
                                                 'regex'      => '([a-zA-Z_][a-zA-Z_0-9]*)',
                                                 'style'      => 'identifier',
@@ -2801,11 +2801,11 @@ $LANGUAGE{'pov'}        = {
                                             ]
                             };
 $LANGUAGE{'povray'}     = $LANGUAGE{'pov'};
-   
- 
 
 
-# by Tom Good 
+
+
+# by Tom Good
 $LANGUAGE{'python'}        = {
                             'filename'   => '(?i)\\.py$',
                             'regex'      => '^\\s*#\\s*![^\\s]*python',
@@ -2813,27 +2813,27 @@ $LANGUAGE{'python'}        = {
                                               {
                                                 'name'       => 'python comment',
                                                 'regex'      => '#.*?$',
-					        'style'      => 'comment',
+                                                'style'      => 'comment',
                                                 'childregex' => []
                                               },
-					      {
+                                              {
                                                 'name'       => 'single quote string',
                                                 'regex'      => '\'.*?\'',
-					        'style'      => 'string',
+                                                'style'      => 'string',
                                                 'childregex' => []
                                               },
-                                                            
+
                                               {
                                                 'name'       => 'string',
                                                 'regex'      => '""|"\\\\\\\\"|".*?([^\\\\](\\\\\\\\)*)"',
                                                 'regex'      => '""|".*?([^\\\\](\\\\\\\\)*)"|"\\\\\\\\"',
                                                 'regex'      => '""|"\\\\\\\\"|"[^"\\\\]"|"[^"].*?[^\\\\]"',
-					        'style'      => 'string',
+                                                'style'      => 'string',
                                                 'childregex' => [
                                                                   {
                                                                     'name'       => 'esc character',
                                                                     'regex'      => '\\\\.',
-					                            'style'      => 'esc character',
+                                                                    'style'      => 'esc character',
                                                                     'childregex' => []
                                                                   }
                                                                 ]
@@ -2841,12 +2841,12 @@ $LANGUAGE{'python'}        = {
                                               {
                                                 'name'       => 'character constant',
                                                 'regex'      => '\'(\\\\)?.\'',
-					        'style'      => 'character',
+                                                'style'      => 'character',
                                                 'childregex' => [
                                                                   {
                                                                     'name'       => 'esc character',
                                                                     'regex'      => '\\\\.',
-					                            'style'      => 'esc character',
+                                                                    'style'      => 'esc character',
                                                                     'childregex' => []
                                                                   }
                                                                 ]
@@ -2854,62 +2854,62 @@ $LANGUAGE{'python'}        = {
                                               {
                                                 'name'       => 'numeric constant',
                                                 'regex'      => '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f)?\\b',
-					        'style'      => 'numeric',
+                                                'style'      => 'numeric',
                                                 'childregex' => []
                                               },
                                               {
                                                 'name'       => 'keyword',
                                                 'regex'      => '\\b(and|assert|break|class|continue|del|elif|else|except|exec|finally|for|from|global|if|import|in|is|lambda|not|or|pass|print|raise|return|try|while)\\b',
-					        'style'      => 'reserved word',
+                                                'style'      => 'reserved word',
                                                 'childregex' => []
                                               },
                                               {
                                                 'name'       => 'braces',
                                                 'regex'      => '[\\{\\}]',
-					        'style'      => 'braces',
+                                                'style'      => 'braces',
                                                 'childregex' => []
                                               },
                                               {
                                                 'name'       => 'symbols',
                                                 'regex'      => '([\\*\\-\\+=:;%&\\|<>\\(\\)\\[\\]!])',
-					        'style'      => 'symbol',
+                                                'style'      => 'symbol',
                                                 'childregex' => []
                                               },
                                               {
                                                 'name'       => 'identifiers',
                                                 'regex'      => '([a-zA-Z_][a-zA-Z_0-9]*)',
-					        'style'      => 'identifier',
+                                                'style'      => 'identifier',
                                                 'childregex' => []
                                               },
                                               {
                                                 'name'       => 'function',
                                                 'regex'      => '[\\t ]*def[\\t ]+([a-zA-Z0-9_]+)[\\t \\(]+.*?[\\n{]',
-					        'style'      => 'function header',
+                                                'style'      => 'function header',
                                                 'childregex' => [
                                                                   {
                                                                     'name'       => 'function args',
                                                                     'regex'      => '\\(.*?\\)',
-					                            'style'      => 'function header args',
+                                                                    'style'      => 'function header args',
                                                                     'childregex' => []
                                                                   },
                                                                   {
                                                                     'name'       => 'function name',
                                                                     'regex'      => '[\\t ][a-zA-Z0-9_]+',
-					                            'style'      => 'function header name',
+                                                                    'style'      => 'function header name',
                                                                     'childregex' => []
                                                                   }
                                                                 ]
-                                              },  
+                                              },
                                               {
                                                 'name'       => 'library functions',
                                                 'regex'      => '\\b(__import__|abs|apply|buffer|callable|chr|cmp|coerce|compile|complex|delatter|dir|divmod|eval|execfile|filter|float|getattr|globals|hasattr|hash|hex|id|input|int|intern|isinstance|issubclass|len|list|locals|long|map|max|min|oct|open|ord|pow|range|raw_input|reduce|reload|repr|round|setattr|slice|str|tuple|type|unichr|unicode|vars|xrange|zip)\\b',
-					        'style'      => 'library function',
+                                                'style'      => 'library function',
                                                 'childregex' => []
                                               },
                                             ]
                           };
 
- 
+
 
 # by Joshua Swink <jswink AT pacbell.net>
 $LANGUAGE{'ruby'}       = {
@@ -3149,8 +3149,8 @@ $LANGUAGE{'sql'}        = {
                                             ]
                             };
 
-   
- 
+
+
 
 # enhanced by W. Friebel
 $LANGUAGE{'patch'}        = {
@@ -3198,45 +3198,45 @@ $LANGUAGE{'patch'}        = {
 #
 
 $LANGUAGE{'shellscript'} = {
-	'filename' => '\\.(sh|shell)$',
-	'regex' => '^\\s*#\\s*![^\\s]*(sh|bash|ash|zsh|ksh)',
-	'patterns' => [ {
-		'name' => 'comment',
-#		'regex' => '^[ \t]*[^$]?\#[^!]?.*?$',
-		'regex' => '(^| )#([^\\!].)*?$',
-		'style' => 'comment',
-		'childregex' => []
-	}, {
-		'name' => 'identifier',
-		'regex' => '[a-zA-Z][a-zA-Z0-9_]*=',
-		'style' => 'identifier',
-		'childregex' => [ {
-			'name' => 'identifier',
-			'regex' => '[a-zA-Z][a-zA-Z0-9_]*',
-			'style' => 'identifier',
-			'childregex' => []
-		} ]
-	}, {
-		'name' => 'identifier',
-		'regex' => '\\$([0-9#\\*]|[a-zA-Z][a-zA-Z0-9_]*)',
-		'style' => 'identifier',
-		'childregex' => []
-	}, {
-		'name' => 'interpreter line',
-		'regex' => '^[ \t]*#!.*?$',
-		'style' => 'preprocessor',
-		childregex => []
-	}, {
-		'name' => 'string',
-		'regex' => '""|"(\\\\"|[^\\"])*"',
-		'style' => 'string',
-		childregex => [ {
-			'name' => 'identifier',
-			'regex' => '\\$([0-9#\\*]|[a-zA-Z][a-zA-Z0-9_]*)',
-			'style' => 'identifier',
-			'childregex' => []
-		} ]
-	} ]
+        'filename' => '\\.(sh|shell)$',
+        'regex' => '^\\s*#\\s*![^\\s]*(sh|bash|ash|zsh|ksh)',
+        'patterns' => [ {
+                'name' => 'comment',
+#               'regex' => '^[ \t]*[^$]?\#[^!]?.*?$',
+                'regex' => '(^| )#([^\\!].)*?$',
+                'style' => 'comment',
+                'childregex' => []
+        }, {
+                'name' => 'identifier',
+                'regex' => '[a-zA-Z][a-zA-Z0-9_]*=',
+                'style' => 'identifier',
+                'childregex' => [ {
+                        'name' => 'identifier',
+                        'regex' => '[a-zA-Z][a-zA-Z0-9_]*',
+                        'style' => 'identifier',
+                        'childregex' => []
+                } ]
+        }, {
+                'name' => 'identifier',
+                'regex' => '\\$([0-9#\\*]|[a-zA-Z][a-zA-Z0-9_]*)',
+                'style' => 'identifier',
+                'childregex' => []
+        }, {
+                'name' => 'interpreter line',
+                'regex' => '^[ \t]*#!.*?$',
+                'style' => 'preprocessor',
+                childregex => []
+        }, {
+                'name' => 'string',
+                'regex' => '""|"(\\\\"|[^\\"])*"',
+                'style' => 'string',
+                childregex => [ {
+                        'name' => 'identifier',
+                        'regex' => '\\$([0-9#\\*]|[a-zA-Z][a-zA-Z0-9_]*)',
+                        'style' => 'identifier',
+                        'childregex' => []
+                } ]
+        } ]
 };
 
 $LANGUAGE{'sh'} = $LANGUAGE{'shellscript'};
@@ -3284,8 +3284,8 @@ __END__
   use Code2HTML;
   $html = code2html( $sourcecode );
   # or
-  code2html( infile        => 'file.java' , 
-             outfile       => 'file.html', 
+  code2html( infile        => 'file.java' ,
+             outfile       => 'file.html',
              linenumbers   => 1 ,
              langmode      => 'perl' ,
              # many other options
@@ -3298,7 +3298,7 @@ either as a simple code2html() function call, or as an Apache handler.
 
 This package is an adaptation of Peter Palfrader's code2html application.
 
-The statement 
+The statement
 
  use Code2HTML;
 
@@ -3318,7 +3318,7 @@ exports the function code2html(), which takes the following arguments
                         linenumbers     => 1,           # turn on linenumbers
                         linknumbers     => 1,           # linenumber links
                         line_number_prefix => '-',      # linenumber anchors
-                        replacetabs     => 8,           # tabs to spaces 
+                        replacetabs     => 8,           # tabs to spaces
 
                         noheader        => '',          # don't use template
                         template        => 'filename',  # override template
@@ -3327,9 +3327,9 @@ exports the function code2html(), which takes the following arguments
                         content_type    => 1,           # output httpd header
                   );
 
-All input parameters are optional except the source code 
+All input parameters are optional except the source code
 specification, which must be defined by either input or infile keys, or
-by passing exactly one argument which will then be taken to be the 
+by passing exactly one argument which will then be taken to be the
 source code.
 
  input          source code to be converted (or set source -infile)
@@ -3346,10 +3346,10 @@ source code.
 
  langfile       filename of file with alternative syntax definitions
 
- outfile        name of file to put html in.  If omitted, 
+ outfile        name of file to put html in.  If omitted,
                 just return html in $html=code2html(...)
 
- outputformat   style of output html.  Available formats are 
+ outputformat   style of output html.  Available formats are
                 html (default), html-dark, html-light, html-nobg.
 
  replacetabs    replace tabs in source with given number of spaces
@@ -3357,7 +3357,7 @@ source code.
  title          set title of output html page
 
  content_type   output a Content-Type httpd header
- 
+
  linenumbers    print line numbers in source code listing
 
 =head1 AUTHOR

--- a/configure
+++ b/configure
@@ -486,7 +486,7 @@ dpkg            Y       # for debian systems, fallback is tar+g(un)zip
 # please change to Y on MacOSX
 #
 lsbom           N       # we are not on MacOSX
-plisutil        N       # we are not on MacOSX
+plistutil       N       # we are not on MacOSX
 bsd_cpio        N       # we are not on MacOSX
 tarcolor        Y       # to colorize tar listings
 

--- a/configure
+++ b/configure
@@ -466,7 +466,7 @@ xlhtml		Y
 dpkg		Y	# for debian systems, fallback is tar+g(un)zip
 ### please change to Y on MacOSX
 lsbom		N	# we are not on MacOSX
-plutil		N	# we are not on MacOSX
+plisutil		N	# we are not on MacOSX
 bsd_cpio	N	# we are not on MacOSX
 tarcolor	Y	# to colorize tar listings
 

--- a/configure
+++ b/configure
@@ -75,21 +75,21 @@ MODE = $mode
 .PHONY: install
 
 all:
-        ./configure --prefix=\$(PREFIX) --nomake \$(MODE)
+	./configure --prefix=\$(PREFIX) --nomake \$(MODE)
 test:
-        ./test.pl
+	./test.pl
 install:
-        mkdir -p \$(DESTDIR)\$(PREFIX)/bin
-        mkdir -p \$(DESTDIR)\$(PREFIX)/share/man/man1
-        cp ./code2color ./sxw2txt ./tarcolor ./lesspipe.sh \$(DESTDIR)\$(PREFIX)/bin
-        cp ./lesspipe.1 \$(DESTDIR)\$(PREFIX)/share/man/man1
-        chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/lesspipe.sh
-        chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/sxw2txt
-        chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/code2color
-        chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/tarcolor
+	mkdir -p \$(DESTDIR)\$(PREFIX)/bin
+	mkdir -p \$(DESTDIR)\$(PREFIX)/share/man/man1
+	cp ./code2color ./sxw2txt ./tarcolor ./lesspipe.sh \$(DESTDIR)\$(PREFIX)/bin
+	cp ./lesspipe.1 \$(DESTDIR)\$(PREFIX)/share/man/man1
+	chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/lesspipe.sh
+	chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/sxw2txt
+	chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/code2color
+	chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/tarcolor
 clean:
-        mv Makefile Makefile.old
-        rm -f lesspipe.sh
+	mv Makefile Makefile.old
+	rm -f lesspipe.sh
 EOF
   close OUT;
 }

--- a/configure
+++ b/configure
@@ -61,7 +61,7 @@ while (<DATA>) {
     $answer{$1} = $2 if /^(\S+)\s+(\S+)/;
 }
 
-my $mode = $opt_ask ? "" : 
+my $mode = $opt_ask ? "" :
            $opt_yes ? "--yes" :
            $opt_fixed ? "--fixed" :
            "--default";
@@ -75,21 +75,21 @@ MODE = $mode
 .PHONY: install
 
 all:
-	./configure --prefix=\$(PREFIX) --nomake \$(MODE)
+        ./configure --prefix=\$(PREFIX) --nomake \$(MODE)
 test:
-	./test.pl
+        ./test.pl
 install:
-	mkdir -p \$(DESTDIR)\$(PREFIX)/bin
-	mkdir -p \$(DESTDIR)\$(PREFIX)/share/man/man1
-	cp ./code2color ./sxw2txt ./tarcolor ./lesspipe.sh \$(DESTDIR)\$(PREFIX)/bin
-	cp ./lesspipe.1 \$(DESTDIR)\$(PREFIX)/share/man/man1
-	chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/lesspipe.sh
-	chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/sxw2txt
-	chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/code2color
-	chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/tarcolor
+        mkdir -p \$(DESTDIR)\$(PREFIX)/bin
+        mkdir -p \$(DESTDIR)\$(PREFIX)/share/man/man1
+        cp ./code2color ./sxw2txt ./tarcolor ./lesspipe.sh \$(DESTDIR)\$(PREFIX)/bin
+        cp ./lesspipe.1 \$(DESTDIR)\$(PREFIX)/share/man/man1
+        chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/lesspipe.sh
+        chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/sxw2txt
+        chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/code2color
+        chmod 0755 \$(DESTDIR)\$(PREFIX)/bin/tarcolor
 clean:
-	mv Makefile Makefile.old
-	rm -f lesspipe.sh
+        mv Makefile Makefile.old
+        rm -f lesspipe.sh
 EOF
   close OUT;
 }
@@ -169,7 +169,7 @@ while (<IN>) {
     my @progs = split /,/;
     # check if @progs existing and executable ($in == 1)
     $in = inpath ("Include code anyway", @progs);
-	$anyin = $in;
+        $anyin = $in;
     # line #elif prog1, prog2, ... seen, store prog1, prog2, ... in @progs
   } elsif (/^#elif\s+(.*)/ ) {
     $in = 1 - $anyin;
@@ -181,7 +181,7 @@ while (<IN>) {
     my @progs = split /,/;
     # check if @progs existing and executable ($in == 1)
     $in = inpath ("Include code anyway", @progs);
-	$anyin = $in;
+        $anyin = $in;
     # line #endif encountered, clear list of replacement strings %rep
   } elsif (/^#else\b/ ) {
     $in = 1 - $anyin;
@@ -209,7 +209,7 @@ chmod 0755, "lesspipe.sh.tmp";
 rename "lesspipe.sh.tmp", "lesspipe.sh";
 print "lesspipe.sh with", $ifsyntax eq "n" ? 'out' : '',
       " syntax highlighting created\n";
-print "Please make sure to copy lesspipe.sh ", 
+print "Please make sure to copy lesspipe.sh ",
       $ifsyntax ne 'n' ? "and code2color " : "", "to $opt_prefix/bin\n";
 
 sub inpath {
@@ -231,8 +231,8 @@ sub inpath {
       #next unless m|^/|; # consider only absolute PATH elements
       # skip bzip2 and cabextract if version not at least 1.0
       if (exists $optstr{$prog} and -x "$_/$prog") {
-	my $vs = `$_/$prog $optstr{$prog} 2>&1`;
-	$vs = $1 if $vs =~ /\b(\d+\.\d+)\b/;
+        my $vs = `$_/$prog $optstr{$prog} 2>&1`;
+        $vs = $1 if $vs =~ /\b(\d+\.\d+)\b/;
         if ($vs < 1.0) {
             print "$prog version $vs unuseable, need at least 1.0\n";
             $which_one = "$_/";
@@ -264,10 +264,10 @@ sub inpath {
       my $yesno = get_answer($string, $prog);
       $have{$prog} = $yesno if ! $have{$prog} and $yesno =~ /^[yn]$/i;
       if (exists $optstr{$prog} and $have{$prog} =~ /^\//) {
-	my $vs = `$have{$prog} $optstr{$prog}` if -x $have{$prog};
-	$vs = $1 if $vs =~ /\b(\d+\.\d+)\b/;
+        my $vs = `$have{$prog} $optstr{$prog}` if -x $have{$prog};
+        $vs = $1 if $vs =~ /\b(\d+\.\d+)\b/;
         if ($vs < 1.0) {
-	    $have{$prog} = "";
+            $have{$prog} = "";
             print "$prog version $vs unuseable, need at least 1.0\n";
         }
       }
@@ -296,11 +296,11 @@ sub get_answer {
     $yesno = 'N' if ! $yesno or $yesno =~ /^n/i;
     if ( $yesno =~ m|^/| ) {
       if ( -x $yesno ) {
-	$have{$prog} = $yesno;
-	$yesno = 'y';
+        $have{$prog} = $yesno;
+        $yesno = 'y';
       } else {
-	print "Program $prog not found (or at least not executable)\n";
-	$yesno = '';
+        print "Program $prog not found (or at least not executable)\n";
+        $yesno = '';
       }
     }
   }
@@ -371,9 +371,9 @@ sub check_shell_vers {
     if ( $name eq 'bash' or $name eq 'sh' ) {
       my $tst = `$file -c \'if [[ -n 1 && -n 2 ]];then true;fi 2>&1\'`;
       if ( $tst ) {
-	print "skipping unuseable shell $shell, error msg was $tst";
-	push @bad, $shell;
-	next;
+        print "skipping unuseable shell $shell, error msg was $tst";
+        push @bad, $shell;
+        next;
       }
     }
     $selected_shell = $name if ! $selected_shell;
@@ -392,81 +392,101 @@ sub check_shell_vers {
   return $selected_shell;
 }
 __END__
+
+
 # the answers configured here do only apply when ./configure --fixed is used
-#sample lines (without the comment sign #):
-#sample_prog	/opt/apps/bin/sample_prog
-#skip_prog	N
-#take_prog	Y
+# sample lines (without the comment sign)
+#sample_prog    /opt/apps/bin/sample_prog
+#skip_prog      N
+#take_prog      Y
+#file           /usr/bin/file   # it is better to let configure do the checks
 
-#file		/usr/bin/file	# it is better to let configure do the checks
-HILITE		Y		# we do want syntax highlighting for --fixed
-LESS_ADVANCED_PREPROCESSOR N	# always interpret textlike files (html, ...)
 
+HILITE          Y               # we do want syntax highlighting for --fixed
+LESS_ADVANCED_PREPROCESSOR N    # always interpret textlike files (html, ...)
+
+#
 # compression programs
-bzip2		Y	# include bzip2 and unzip code, it is fairly essential
-unzip		Y
-rar		Y
-unrar		Y
-lzip		N	# default for lzma, lzip, xz, 7za should probably be N
-lzma		Y
-xz		Y
-7za		Y
-7zr		N	# included in 7za code
-zstd		Y
-brotli		Y
-lz4		Y
+#
+bzip2           Y       # include bzip2 and unzip code, it is fairly essential
+unzip           Y
+rar             Y
+unrar           Y
+lzip            N       # default for lzma, lzip, xz, 7za should probably be N
+lzma            Y
+xz              Y
+7za             Y
+7zr             N       # included in 7za code
+zstd            Y
+brotli          Y
+lz4             Y
+
+#
 # essential utilities
-cpio		Y
-elinks		Y	# only one of html2text, elinks, links, lynx, w3m needed
-groff		Y
-html2text	Y	# rarely found but is a good alternative to elinks
-iconv		Y
-links		Y
-lynx		Y
-nm		Y
-rpm		Y
-rpmunpack	N	# fallback for rpm2cpio only, code inserted anyway
-rpm2cpio	Y
-w3m		Y
+#
+cpio            Y
+elinks          Y       # only one of html2text, elinks, links, lynx, w3m needed
+groff           Y
+html2text       Y       # rarely found but is a good alternative to elinks
+iconv           Y
+links           Y
+lynx            Y
+nm              Y
+rpm             Y
+rpmunpack       N       # fallback for rpm2cpio only, code inserted anyway
+rpm2cpio        Y
+w3m             Y
+
+#
 # code for these programs should be included in lesspipe.sh
-doc2txt.pl	Y	  # to view Microsoft Word 2007+ files
-pandoc	    Y	      # to view Microsoft Word 2007+ files
-libreoffice	Y	  # to view Microsoft Office 2007+ files
-antiword	Y	# one of antiword or catdoc or wvText should be installed
-catdoc		Y
-wvText		Y
-dvi2tty		Y	# nice to have
-pstotext	Y	# pstotext is better than the fallback ps2ascii
-ps2ascii	N	# ps2ascii code is already in the pstotext part
-iconv		Y
-gpg		Y
-pdftohtml	Y
-pdftotext	Y
-pdfinfo	Y
+#
+doc2txt.pl      Y         # to view Microsoft Word 2007+ files
+pandoc          Y         # to view Microsoft Word 2007+ files
+libreoffice     Y         # to view Microsoft Office 2007+ files
+antiword        Y         # one of antiword or catdoc or wvText should be installed
+catdoc          Y
+wvText          Y
+dvi2tty         Y         # nice to have
+pstotext        Y         # pstotext is better than the fallback ps2ascii
+ps2ascii        N         # ps2ascii code is already in the pstotext part
+iconv           Y
+gpg             Y
+pdftohtml       Y
+pdftotext       Y
+pdfinfo         Y
+
+#
 # other helper programs
-cabextract	Y
-matdump	N
-djvutxt		Y
-fastjar		N	# I do prefer unzip
-gpg		Y
-mediainfo	Y
-exiftool	N # is mediainfo or exiftool better?
-id3v2		  Y	# id3v2 is preferred over mp3info if both selected
-mp3info2	N	# code for mp3info2 is included anyway if id3v2 selected
-mp3info		N	# code for mp3info is included anyway if id3v2 selected
-identify	Y
-isoinfo		Y	# I would not want to see that
-o3tohtml	Y
-openssl		Y
-perldoc		Y
-ppthtml		Y
-unrtf		Y
-xlhtml		Y
+#
+cabextract      Y
+matdump         N
+djvutxt         Y
+fastjar         N       # I do prefer unzip
+gpg             Y
+mediainfo       Y
+exiftool        N       # (exiftool allows to dig deeper, mediainfo is more versatile)
+id3v2           Y       # id3v2 is preferred over mp3info if both selected
+mp3info2        N       # code for mp3info2 is included anyway if id3v2 selected
+mp3info         N       # code for mp3info is included anyway if id3v2 selected
+identify        Y
+isoinfo         Y       # I would not want to see that
+o3tohtml        Y
+openssl         Y
+perldoc         Y
+ppthtml         Y
+unrtf           Y
+xlhtml          Y
+
+#
 # for specific operating systems
-dpkg		Y	# for debian systems, fallback is tar+g(un)zip
-### please change to Y on MacOSX
-lsbom		N	# we are not on MacOSX
-plisutil		N	# we are not on MacOSX
-bsd_cpio	N	# we are not on MacOSX
-tarcolor	Y	# to colorize tar listings
+#
+dpkg            Y       # for debian systems, fallback is tar+g(un)zip
+
+#
+# please change to Y on MacOSX
+#
+lsbom           N       # we are not on MacOSX
+plisutil        N       # we are not on MacOSX
+bsd_cpio        N       # we are not on MacOSX
+tarcolor        Y       # to colorize tar listings
 

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -933,9 +933,9 @@ isfinal() {
   elif [[ "$1" = *GPG\ encrypted\ data* || "$1" = *PGP\ *ncrypted* ]] && cmd_exist gpg; then
     msg "append $sep to filename to view the encrypted file"
     gpg -d "$2"
-  elif [[ "$1" = *Apple\ binary\ property\ list* ]] && cmd_exist plutil; then
+  elif [[ "$1" = *Apple\ binary\ property\ list* ]] && cmd_exist plisutil; then
     msg "append $sep to filename to view the raw data"
-    plutil -convert xml1 -o - "$2"
+    plisutil -convert xml1 -o - "$2"
   elif [[ "$2" = *.crt || "$2" = *.pem ]] && cmd_exist openssl; then
     msg "append $sep to filename to view the raw data"
     openssl x509 -hash -text -noout -in "$2"

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -795,11 +795,11 @@ isfinal() {
     msg "append $sep to filename to view the DjVu source"
     djvutxt "$2"
   elif [[ "$1" = *Microsoft\ Word\ 2007* ]]; then
-    if cmd_exist docx2txt.pl; then
+    if cmd_exist docx2txt; then
       msg "append $sep to filename to view the raw word document"
-      docx2txt.pl "$2" -
+      docx2txt "$2" -
     else
-      msg "install docx2txt.pl to view human readable text"
+      msg "install docx2txt to view human readable text"
       cat "$2"
     fi
   elif [[ "$1" = *OpenDocument\ Text* ]]; then

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -42,9 +42,6 @@ PATH=$PATH:$dir
 cmd_exist () {
   command -v "$1" > /dev/null 2>&1 && return 0 || return 1
 }
-if [[ "$LESS_ADVANCED_PREPROCESSOR" = '' ]]; then
-   NOL_A_P=_NO_L_A_P
-fi
 
 filecmd() {
   file -L -s "$@"
@@ -53,10 +50,8 @@ filecmd() {
 
 TMPDIR=${TMPDIR:-/tmp}
 
-# file name separator
 sep=:
 
-# alternate separator character
 altsep==
 
 if [[ -e "$1" && "$1" = *$sep* || "$1" = *$sep*$altsep* ]]; then
@@ -64,6 +59,7 @@ if [[ -e "$1" && "$1" = *$sep* || "$1" = *$sep*$altsep* ]]; then
   xxx="${1%=}"
   set "$xxx"
 fi
+
 tmpdir="$TMPDIR"/lesspipe."$RANDOM"
 mkdir "$tmpdir"
 
@@ -108,11 +104,13 @@ filetype () {
   if [[ "$1" = - ]]; then
     name="$filen"
   fi
+  # ifdef brotli
   if [[ ("$name" = *.br || "$name" = *.bro || "$name" = *.tbr) ]]; then
     # In current format, brotli can only be detected by extension
     echo " brotli compressed data"
     return
   fi
+  # endif
   if [[ "$1" = - ]]; then
     dd bs=40000 count=1 > "$tmpdir/file" 2>/dev/null
     set "$tmpdir/file" "$2"
@@ -125,86 +123,85 @@ filetype () {
   if [[ "$type" = " empty" ]]; then
     # exit if file returns "empty" (e.g., with "less archive:nonexisting_file")
     exit 1
-       # Open Office
+    # Open Office
   elif [[ "$type" = *OpenDocument\ Text* ]]; then
     return=" OpenDocument Text"
   elif [[ "$type" = *OpenDocument\ * || "$type" = *OpenOffice\.org\ 1\.x\ * ]]; then
-      return=" OpenDocument"
-       # Microsoft Office <  2007
+    return=" OpenDocument"
+    # Microsoft Office <  2007
   elif [[ "$type" = *Microsoft\ Office\ Document* && ("$name" = *.do[st]) ]] ||
-       [[ "$type" = *Microsoft\ Office\ Word* ]]; then
-       return=" Microsoft Word Document"
-  elif [[ "$type" = *Microsoft\ Office\ Document* && ("$name" = *.pp[st]) ]] ||
-       [[ "$type" = *Microsoft\ Office\ PowerPoint* ]]; then
-       return=" Microsoft PowerPoint Document"
+    [[ "$type" = *Microsoft\ Office\ Word* ]]; then
+  return=" Microsoft Word Document"
+elif [[ "$type" = *Microsoft\ Office\ Document* && ("$name" = *.pp[st]) ]] ||
+  [[ "$type" = *Microsoft\ Office\ PowerPoint* ]]; then
+return=" Microsoft PowerPoint Document"
   elif [[ "$type" = *Microsoft\ Office\ Document* && ("$name" = *.xl[mst]) ]] ||
-       [[ "$type" = *Microsoft\ Excel* ]]; then
-       return=" Microsoft Excel Document"
-  elif [[ "$type" = *Microsoft\ Office\ Document* || "$type" = *Composite\ Document\ File\ V2* ]]; then
-       return=" Microsoft Office Document"
-       # Microsoft Office >= 2007
-  elif [[ ("$type" = *Zip\ archive* || "$type" =  Microsoft\ OOXML) && "$name" = *.do[ct][xm] ]] ||
-       [[ "$type" = *Microsoft\ Word\ 2007* ]]; then
-       return=" Microsoft Word 2007+"
+    [[ "$type" = *Microsoft\ Excel* ]]; then
+  return=" Microsoft Excel Document"
+elif [[ "$type" = *Microsoft\ Office\ Document* || "$type" = *Composite\ Document\ File\ V2* ]]; then
+  return=" Microsoft Office Document"
+  # Microsoft Office >= 2007
+elif [[ ("$type" = *Zip\ archive* || "$type" =  Microsoft\ OOXML) && "$name" = *.do[ct][xm] ]] ||
+  [[ "$type" = *Microsoft\ Word\ 2007* ]]; then
+return=" Microsoft Word 2007+"
   elif [[ ("$type" = *Zip\ archive* || "$type" =  Microsoft\ OOXML) && "$name" = *.pp[st][xm] ]] ||
-       [[ "$type" = *Microsoft\ PowerPoint\ 2007* ]]; then
-       return=" Microsoft PowerPoint 2007+"
-  elif [[ ("$type" = *Zip\ archive* || "$type" =  Microsoft\ OOXML) && "$name" = *.xl[st][xmb] ]] ||
-       [[ "$type" = *Microsoft\ Excel\ 2007* ]]; then
-       return=" Microsoft Excel 2007+"
+    [[ "$type" = *Microsoft\ PowerPoint\ 2007* ]]; then
+  return=" Microsoft PowerPoint 2007+"
+elif [[ ("$type" = *Zip\ archive* || "$type" =  Microsoft\ OOXML) && "$name" = *.xl[st][xmb] ]] ||
+  [[ "$type" = *Microsoft\ Excel\ 2007* ]]; then
+return=" Microsoft Excel 2007+"
   elif [[ "$type" =  Microsoft\ OOXML ]] ||
-       [[ "$type" = *Microsoft\ *\ 2007* ]]; then
-       return=" Microsoft Office 2007"
-       # MP3
-  elif [[ "$type" = *MPEG\ *layer\ 3\ audio* || "$type" = *MPEG\ *layer\ III* || "$type" = *mp3\ file* || "$type" = *MP3* ]]; then
-    return="mp3"
-       # Compressed Archives
-  elif [[ "$type" != *lzip\ compressed* && ("$name" = *.lzma || "$name" = *.tlz) ]]; then
-    return=" LZMA compressed data"
-  elif [[ ("$type" = *Zip* || "$type" = *ZIP* || "$type" = *JAR*) && ("$name" = *.jar || "$name" = *.xpi) ]]; then
-    return=" Zip compressed Jar archive"
-  elif [[ "$type" = *Hierarchical\ Data\ Format* && ("$name" = *.nc4) ]]; then
-       return=" NetCDF Data Format data"
-       # Sometimes a BSD makefile is identified as "troff or preprocessor input
-       # text" probably due to its ".if" style directives.
-  elif [[ "$type" = *roff\ *,* && ("$name" = */[Mm]akefile || "$name" = */[Mm]akefile.* || "$name" = */BSDmakefile || "$name" = *.mk) ]]; then
-       return=" BSD makefile script,${type#*,}}"
-       # Correct HTML Detection
-  elif [[ ("$type" = *HTML* || "$type" = *ASCII*) && "$name" = *xml ]]; then
-    return=" XML document text"
-  elif [[ "$type" = *XML* && "$name" = *html ]]; then
-    return=" HTML document text"
-  fi
+    [[ "$type" = *Microsoft\ *\ 2007* ]]; then
+  return=" Microsoft Office 2007"
+  # MP3
+elif [[ "$type" = *MPEG\ *layer\ 3\ audio* || "$type" = *MPEG\ *layer\ III* || "$type" = *mp3\ file* || "$type" = *MP3* ]]; then
+  return="mp3"
+  # Compressed Archives
+elif [[ "$type" != *lzip\ compressed* && ("$name" = *.lzma || "$name" = *.tlz) ]]; then
+  return=" LZMA compressed data"
+elif [[ ("$type" = *Zip* || "$type" = *ZIP* || "$type" = *JAR*) && ("$name" = *.jar || "$name" = *.xpi) ]]; then
+  return=" Zip compressed Jar archive"
+elif [[ "$type" = *Hierarchical\ Data\ Format* && ("$name" = *.nc4) ]]; then
+  return=" NetCDF Data Format data"
+  # Sometimes a BSD makefile is identified as "troff or preprocessor input
+  # text" probably due to its ".if" style directives.
+elif [[ "$type" = *roff\ *,* && ("$name" = */[Mm]akefile || "$name" = */[Mm]akefile.* || "$name" = */BSDmakefile || "$name" = *.mk) ]]; then
+  return=" BSD makefile script,${type#*,}}"
+  # Correct HTML Detection
+elif [[ ("$type" = *HTML* || "$type" = *ASCII*) && "$name" = *xml ]]; then
+  return=" XML document text"
+elif [[ "$type" = *XML* && "$name" = *html ]]; then
+  return=" HTML document text"
+fi
 
-  if [[ -n "$return" ]]; then
-    echo "$return"
-    return
-  fi
-
-  # file -b not supported by all versions of 'file'
-  mime="$(file -i "$1" | cut -d : -f 2-)"
-  if [[ "$mime" = \ text/* ]]; then
-    return="text"
-  elif [[ "$mime" = \ image/* ]]; then
-    return="image"
-  elif [[ "$mime" = \ audio/* ]]; then
-    return="audio"
-  elif [[ "$mime" = \ video/* ]]; then
-    return="video"
-  fi
-
-  if [[ -n "$return" ]]; then
-    echo "$return"
-    return
-  fi
-
-  if [[ -n "$mime" ]]; then
-    return="$mime"
-  else
-    return=""
-  fi
-
+if [[ -n "$return" ]]; then
   echo "$return"
+  return
+fi
+
+mime="$(file -i "$1" | cut -d : -f 2-)"
+if [[ "$mime" = \ text/* ]]; then
+  return="text"
+elif [[ "$mime" = \ image/* ]]; then
+  return="image"
+elif [[ "$mime" = \ audio/* ]]; then
+  return="audio"
+elif [[ "$mime" = \ video/* ]]; then
+  return="video"
+fi
+
+if [[ -n "$return" ]]; then
+  echo "$return"
+  return
+fi
+
+if [[ -n "$mime" ]]; then
+  return="$mime"
+else
+  return=""
+fi
+
+echo "$return"
 }
 
 show () {
@@ -387,7 +384,7 @@ get_cmd () {
   rsave="$rest1"
   rest1="$rest2"
   if [[ "$file2" != "" ]]; then
-    if [[ "$1" = *\ tar* || "$1" = *\   tar* ]]; then
+    if [[ "$1" = *\ tar* || "$1" = *\ tar* ]]; then
       cmd=(istar "$2" "$file2")
     elif [[ "$1" = *Debian* ]]; then
       data="$(ar t "$2"|grep data.tar)"
@@ -400,10 +397,6 @@ get_cmd () {
         istemp "ar p" "$2" "$data" | $("${cmd2[@]}") > "$t"
       fi
       cmd=(istar "$t" "$file2")
-    elif [[ "$1" = *RPM* ]] && cmd_exist cpio && ( cmd_exist rpm2cpio || cmd_exist rpmunpack ); then
-      cmd=(isrpm "$2" "$file2")
-    elif [[ "$1" = *Jar\ archive* || "$1" = *Java\ archive* ]] && cmd_exist fastjar; then
-      cmd=(isjar "$2" "$file2")
     elif [[ "$1" = *Zip* || "$1" = *ZIP* || "$1" = *JAR* ]] && cmd_exist unzip; then
       cmd=(istemp "unzip -avp" "$2" "$file2")
     elif [[ "$1" = *RAR\ archive* ]]; then
@@ -418,8 +411,6 @@ get_cmd () {
       cmd=(istemp "7za e -so" "$2" "$file2")
     elif [[ "$1" = *7-zip\ archive* || "$1" = *7z\ archive* ]] && cmd_exist 7zr; then
       cmd=(istemp "7zr e -so" "$2" "$file2")
-    elif [[ "$1" = *[Cc]abinet* ]] && cmd_exist cabextract; then
-      cmd=(iscab "$2" "$file2")
     elif [[ "$1" = *\ ar\ archive* ]]; then
       cmd=(istemp "ar p" "$2" "$file2")
     elif [[ "$1" = *ISO\ 9660* ]] && cmd_exist isoinfo; then
@@ -431,15 +422,6 @@ get_cmd () {
   fi
 }
 
-iscab () {
-  typeset t
-  if [[ "$1" = - ]]; then
-    t=$(nexttmp)
-    cat > "$t"
-    set "$t" "$2"
-  fi
-  cabextract -pF "$2" "$1"
-}
 
 istar () {
   $tarcmd Oxf "$1" "$2" 2>/dev/null
@@ -512,26 +494,6 @@ isrpm () {
   fi
 }
 
-isjar () {
-  case "$2" in
-    /*) echo "lesspipe can't unjar files with absolute paths" >&2
-      exit 1
-      ;;
-    ../*) echo "lesspipe can't unjar files with ../ paths" >&2
-      exit 1
-      ;;
-  esac
-  typeset d
-  d=$(nexttmp -d)
-  [[ -d "$d" ]] || exit 1
-  cat "$1" | (
-    cd "$d" || return
-    fastjar -x "$2"
-    if [[ -f "$2" ]]; then
-      cat "$2"
-    fi
-  )
-}
 
 #parsexml () { nodash "elinks -dump -default-mime-type text/xml" "$1"; }
 parsehtml () {
@@ -545,11 +507,6 @@ parsehtml () {
     lynx -dump -force_html "$1" && return
   elif cmd_exist w3m; then
     nodash "w3m -dump -T text/html" "$1"
-  elif cmd_exist elinks; then
-    nodash "elinks -dump -force-html" "$1"
-  elif cmd_exist links; then
-    if [[ "$1" = - ]]; then set - -stdin; fi
-    links -dump -force_html "$1"
   fi
 }
 
@@ -586,31 +543,6 @@ isfinal() {
     cat "$2"
     return
   elif [[ $3 = $sep* ]]; then
-    if [[ $3 = "$sep" ]]; then
-      msg "append :. or :<filetype> to activate syntax highlighting"
-    else
-      lang=${3#$sep}
-      lang="-l${lang#.}"
-      lang=${lang%%-l }
-      if cmd_exist bat; then
-        if [[ "$lang" = "-l" ]]; then
-          bat $COLOR "$2"
-        else
-          bat $COLOR "$lang" "$2"
-        fi
-        [[ $? = 0 ]] && return
-      elif cmd_exist batcat; then
-        if [[ "$lang" = "-l" ]]; then
-          batcat $COLOR "$2"
-        else
-          batcat $COLOR "$lang" "$2"
-        fi
-        [[ $? = 0 ]] && return
-      elif cmd_exist code2color; then
-        code2color $PPID ${in_file:+"$in_file"} "$lang" "$2"
-        [[ $? = 0 ]] && return
-      fi
-    fi
     cat "$2"
     return
   fi
@@ -633,30 +565,12 @@ isfinal() {
     else
       "${cmd[@]}"
     fi
-  elif [[ "$1" = *\ tar* || "$1" = *\   tar* ]]; then
+  elif [[ "$1" = *\ tar* || "$1" = *\ tar* ]]; then
     msg "use tar_file${sep}contained_file to view a file in the archive"
     if [[ -n $COLOR ]] && cmd_exist tarcolor; then
       $tarcmd tvf "$2" | tarcolor
     else
       $tarcmd tvf "$2"
-    fi
-  elif [[ "$1" = *RPM* ]]; then
-    header="use RPM_file${sep}contained_file to view a file in the RPM"
-    if cmd_exist rpm; then
-      echo "$header"
-      istemp "rpm -qivp" "$2"
-      header="";
-    fi
-    if cmd_exist cpio && cmd_exist rpm2cpio; then
-      echo $header
-      echo "================================= Content ======================================"
-      istemp rpm2cpio "$2" 2>/dev/null|cpio -i -tv 2>/dev/null
-    elif cmd_exist cpio && cmd_exist rpmunpack; then
-      echo $header
-      echo "================================= Content ======================================"
-      cat "$2" | rpmunpack | gzip -cd | cpio -i -tv 2>/dev/null
-    else
-      msg "please install rpm2cpio or rpmunpack to see the contents of RPM files"
     fi
   elif [[ "$1" = *roff* ]] && cmd_exist groff; then
     DEV=utf8
@@ -689,14 +603,14 @@ isfinal() {
     istemp "ar p" "$2" "$data" | $("${cmd2[@]}") | $tarcmd tvf -
   # do not display all perl text containing pod using perldoc
   #elif [[ "$1" = *Perl\ POD\ document\ text* || "$1" = *Perl5\ module\ source\ text* ]]; then
-  elif [[ "$1" = *Perl\ POD\ document\ text$NOL_A_P* ]] && cmd_exist perldoc; then
+  elif [[ "$1" = *Perl\ POD\ document\ text* ]] && cmd_exist perldoc; then
     msg "append $sep to filename to view the perl source"
     istemp perldoc "$2"
   elif [[ "$1" = *\ script* ]]; then
     set "plain text" "$2"
   elif [[ "$1" = *text\ executable* ]]; then
     set "plain text" "$2"
-  elif [[ "$1" = *PostScript$NOL_A_P* ]]; then
+  elif [[ "$1" = *PostScript* ]]; then
     if cmd_exist ps2ascii; then
       msg "append $sep to filename to view the postscript file"
       nodash ps2ascii "$2"
@@ -710,9 +624,6 @@ isfinal() {
   elif [[ "$1" = *shared* ]] && cmd_exist nm; then
     msg "This is a dynamic library, showing the output of nm"
     istemp nm "$2"
-  elif [[ "$1" = *Jar\ archive* ]] && cmd_exist fastjar; then
-    msg "use jar_file${sep}contained_file to view a file in the archive"
-    nodash "fastjar -tf" "$2"
   elif [[ "$1" = *Zip* || "$1" = *ZIP* || "$1" = *JAR* ]] && cmd_exist unzip; then
     msg "use zip_file${sep}contained_file to view a file in the archive"
     istemp "unzip -lv" "$2"
@@ -765,13 +676,10 @@ isfinal() {
       msg "use 7za_file${sep}contained_file to view a file in the archive"
       echo "$res"
     fi
-  elif [[ "$1" = *[Cc]abinet* ]] && cmd_exist cabextract; then
-    msg "use cab_file${sep}contained_file to view a file in the cabinet"
-    istemp "cabextract -l" "$2"
   elif [[ "$1" = *\ DVI* ]] && cmd_exist dvi2tty; then
     msg "append $sep to filename to view the raw DVI file"
     isdvi "$2"
-  elif [[ "$PARSEHTML" = yes && "$1" = *HTML$NOL_A_P* ]]; then
+  elif [[ "$PARSEHTML" = yes && "$1" = *HTML* ]]; then
     msg "append $sep to filename to view the HTML source"
     parsehtml "$2"
   elif [[ "$1" = *PDF* ]] && cmd_exist pdftotext; then
@@ -789,13 +697,6 @@ isfinal() {
   elif [[ "$1" = *PDF* ]] && cmd_exist pdfinfo; then
       msg "append $sep to filename to view the PDF source"
       istemp pdfinfo "$2"
-  elif [[ "$1" = *Hierarchical\ Data\ Format* ]] && cmd_exist h5dump; then
-    istemp h5dump "$2"
-  elif [[ "$1" = *NetCDF* || "$1" = *Hierarchical\ Data\ Format* ]] && cmd_exist ncdump; then
-    istemp ncdump "$2"
-  elif [[ "$1" = *Matlab\ v[0-9.]*\ mat-file* ]] && cmd_exist matdump; then
-    msg "append $sep to filename to view the raw data"
-    matdump -d "$2"
   elif [[ "$1" = *DjVu* ]] && cmd_exist djvutxt; then
     msg "append $sep to filename to view the DjVu source"
     djvutxt "$2"
@@ -853,7 +754,7 @@ isfinal() {
       msg "install antiword or catdoc to view human readable text"
       cat "$2"
     fi
-  elif [[ "$1" = *Rich\ Text\ Format$NOL_A_P* ]]  && cmd_exist unrtf; then
+  elif [[ "$1" = *Rich\ Text\ Format* ]]  && cmd_exist unrtf; then
     if [[ "$PARSEHTML" = yes ]]; then
       msg "append $sep to filename to view the RTF source"
       istemp "unrtf --html" "$2" | parsehtml -
@@ -861,12 +762,6 @@ isfinal() {
       msg "append $sep to filename to view the RTF source"
       istemp "unrtf --text" "$2" | sed -e "s/^### .*//" | fmt -s
     fi
-  elif [[ "$1" = *Excel\ 2007* ]] && cmd_exist git-xlsx-textconv.pl; then
-    msg "append $sep to filename to view the spreadsheet source"
-    git-xlsx-textconv.pl "$2"
-  elif [[ "$1" = *Excel\ 2007* ]] && cmd_exist git-xlsx-textconv; then
-    msg "append $sep to filename to view the spreadsheet source"
-    git-xlsx-textconv "$2"
   elif [[ "$1" = *PowerPoint\ 2007* ]] && cmd_exist pptx2md; then
     msg "append $sep to filename to view the PowerPoint source"
     name_ext="$(basename "$2")"
@@ -874,7 +769,7 @@ isfinal() {
     output_file="$TMPDIR"/"$name".md
     pptx2md --disable_image --disable_wmf "$2" -o "$output_file" >/dev/null
     cat "$output_file"
-  elif [[ "$1" = *Rich\ Text\ Format$NOL_A_P* ||
+  elif [[ "$1" = *Rich\ Text\ Format* ||
     "$1" = *Microsoft\ Word\ Document* ||
     "$1" = *Microsoft\ Word\ 2007* ||
     "$1" = *OpenDocument\ Text*  ]]; then
@@ -899,17 +794,8 @@ isfinal() {
       msg "install LibreOffice to view human readable text"
       cat "$2"
     fi
-  elif [[ "$PARSEHTML" = yes && "$1" = *Microsoft\ Excel\ Document* ]] && cmd_exist xlhtml; then
-    msg "append $sep to filename to view the spreadsheet source"
-    xlhtml -te "$2" | parsehtml -
-  elif [[ "$PARSEHTML" = yes && "$1" = *Microsoft\ PowerPoint\ Document* ]] && cmd_exist ppthtml; then
-    msg "append $sep to filename to view the PowerPoint source"
-    ppthtml "$2" | parsehtml -
-  elif [[ "$PARSEHTML" = yes && "$1" = *OpenDocument* ]] && cmd_exist unzip; then
-    if cmd_exist o3tohtml; then
-      msg "append $sep to filename to view the OpenOffice or OpenDocument source"
-      istemp "unzip -avp" "$2" content.xml | o3tohtml | parsehtml -
-    elif cmd_exist sxw2txt; then
+  elif [[ "$PARSEHTML" = yes && "$1" = *OpenOffice\ Document* ]] && cmd_exist unzip; then
+    if cmd_exist sxw2txt; then
       msg "append $sep to filename to view the OpenOffice or OpenDocument source"
       istemp sxw2txt "$2"
     else
@@ -926,14 +812,14 @@ isfinal() {
   elif [[ "$1" = *bill\ of\ materials* ]] && cmd_exist lsbom; then
     msg "append $sep to filename to view the raw data"
     lsbom -p MUGsf "$2"
-  elif [[ "$1" = *perl.?[sS]torable$NOL_A_P* ]]; then
+  elif [[ "$1" = *perl.?[sS]torable* ]]; then
     msg "append $sep to filename to view the raw data"
     perl -MStorable=retrieve -MData::Dumper -e '$Data::Dumper::Indent=1;print Dumper retrieve shift' "$2"
-  elif [[ "$1" = *UTF-8$NOL_A_P* && "$lang" != *utf-8* ]] && cmd_exist iconv -c; then
+  elif [[ "$1" = *UTF-8* && "$lang" != *utf-8* ]] && cmd_exist iconv -c; then
     iconv -c -f UTF-8 "$2"
-  elif [[ "$1" = *UTF-16$NOL_A_P* && "$lang" != *utf-16* ]] && cmd_exist iconv -c; then
+  elif [[ "$1" = *UTF-16* && "$lang" != *utf-16* ]] && cmd_exist iconv -c; then
     iconv -c -f UTF-16 "$2"
-  elif [[ "$1" = *ISO-8859$NOL_A_P* && "$lang" != *iso-8859-1* ]] && cmd_exist iconv -c; then
+  elif [[ "$1" = *ISO-8859* && "$lang" != *iso-8859-1* ]] && cmd_exist iconv -c; then
     iconv -c -f ISO-8859-1 "$2"
   elif [[ "$1" = *GPG\ encrypted\ data* || "$1" = *PGP\ *ncrypted* ]] && cmd_exist gpg; then
     msg "append $sep to filename to view the encrypted file"
@@ -941,6 +827,9 @@ isfinal() {
   elif [[ "$1" = *Apple\ binary\ property\ list* ]] && cmd_exist plistutil; then
     msg "append $sep to filename to view the raw data"
     plistutil -convert xml1 -o - "$2"
+  elif [[ "$1" = *data* ]]; then
+    msg "append $sep to filename to view the raw data"
+    nodash strings "$2"
   elif [[ "$2" = *.crt || "$2" = *.pem ]] && cmd_exist openssl; then
     msg "append $sep to filename to view the raw data"
     openssl x509 -hash -text -noout -in "$2"
@@ -970,51 +859,48 @@ isfinal() {
   elif [[ "$1" = "image" || "$1" = "mp3" || "$1" = "audio" || "$1" = "video" ]] && cmd_exist exiftool; then
     msg "append $sep to filename to view the raw data"
     exiftool "$2"
-  elif [[ "$1" = *data$NOL_A_P* ]]; then
-    msg "append $sep to filename to view the raw data"
-    nodash strings "$2"
   fi
 
   if [[ "$1" = *text* ]]; then
     if [[ "$2" != '-' ]]; then
       if [[ "$2" = *.md || "$2" = *.MD || "$2" = *.mkd || "$2" = *.markdown ]] &&
         cmd_exist mdcat; then
-        mdcat "$2"
-      elif [[ "$2" = *.log ]] &&
-        cmd_exist ccze; then
-        cat "$2" | ccze -A
-      else
-        if [[ "$1" = *ASCII\ text* || "$1" = *Unicode\ text* ]]; then
-          cat "$2"
-        elif cmd_exist bat; then
-          bat $COLOR "$2"
-        elif cmd_exist batcat; then
-          batcat $COLOR "$2"
-        # ifdef perl
-        elif cmd_exist code2color; then
-          code2color $PPID ${in_file:+"$in_file"} "$2"
-        #endif
-        else
-          cat "$2"
-        fi
-      fi
+      mdcat "$2"
+    elif [[ "$2" = *.log ]] &&
+      cmd_exist ccze; then
+    cat "$2" | ccze -A
+  else
+    if [[ "$1" = *ASCII\ text* || "$1" = *Unicode\ text* ]]; then
+      cat "$2"
+    elif cmd_exist bat; then
+      bat $COLOR "$2"
+    elif cmd_exist batcat; then
+      batcat $COLOR "$2"
+      # ifdef perl
+    elif cmd_exist code2color; then
+      code2color $PPID ${in_file:+"$in_file"} "$2"
+      #endif
     else
-      # if [[ "$2" = - ]]; then
-        if [[ "$1" = *ASCII\ text* || "$1" = *Unicode\ text* ]]; then
-          cat
-        elif cmd_exist bat; then
-          bat $COLOR
-        elif cmd_exist batcat; then
-          batcat $COLOR
-        # ifdef perl
-        elif cmd_exist code2color; then
-          code2color $PPID ${in_file:+"$in_file"} "$2"
-        #endif
-        else
-          cat
-        fi
-        [[ $? = 0 ]] && return
-      fi
+      cat "$2"
+    fi
+  fi
+else
+  # if [[ "$2" = - ]]; then
+  if [[ "$1" = *ASCII\ text* || "$1" = *Unicode\ text* ]]; then
+    cat
+  elif cmd_exist bat; then
+    bat $COLOR
+  elif cmd_exist batcat; then
+    batcat $COLOR
+    # ifdef perl
+  elif cmd_exist code2color; then
+    code2color $PPID ${in_file:+"$in_file"} "$2"
+    #endif
+  else
+    cat
+  fi
+  [[ $? = 0 ]] && return
+fi
   fi
 
 }
@@ -1027,15 +913,9 @@ if [[ "$a" = "" ]]; then
   fi
   if [[ "$SHELL" = *csh ]]; then
     echo "setenv LESSOPEN \"|$pat$0 %s\""
-    if [[ "$LESS_ADVANCED_PREPROCESSOR" = '' ]]; then
-      echo "setenv LESS_ADVANCED_PREPROCESSOR 1"
-    fi
   else
     echo "LESSOPEN=\"|$pat$0 %s\""
     echo "export LESSOPEN"
-    if [[ "$LESS_ADVANCED_PREPROCESSOR" = '' ]]; then
-      echo "LESS_ADVANCED_PREPROCESSOR=1; export LESS_ADVANCED_PREPROCESSOR"
-    fi
   fi
 else
   # check for pipes so that "less -f ... <(cmd) ..." works properly

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -938,9 +938,9 @@ isfinal() {
   elif [[ "$1" = *GPG\ encrypted\ data* || "$1" = *PGP\ *ncrypted* ]] && cmd_exist gpg; then
     msg "append $sep to filename to view the encrypted file"
     gpg -d "$2"
-  elif [[ "$1" = *Apple\ binary\ property\ list* ]] && cmd_exist plisutil; then
+  elif [[ "$1" = *Apple\ binary\ property\ list* ]] && cmd_exist plistutil; then
     msg "append $sep to filename to view the raw data"
-    plisutil -convert xml1 -o - "$2"
+    plistutil -convert xml1 -o - "$2"
   elif [[ "$2" = *.crt || "$2" = *.pem ]] && cmd_exist openssl; then
     msg "append $sep to filename to view the raw data"
     openssl x509 -hash -text -noout -in "$2"

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -7,21 +7,21 @@
 #===============================================================================
 #
 # Usage:   lesspipe.sh is called when the environment variable LESSOPEN is set:
-#	   LESSOPEN="|lesspipe.sh %s"; export LESSOPEN	(sh like shells)
-#	   setenv LESSOPEN "|lesspipe.sh %s"		(csh, tcsh)
-#	   Use the fully qualified path if lesspipe.sh is not in the search path
-#	   View files in multifile archives:
-#			less archive_file:contained_file
-#	   This can be used to extract ASCII files from a multifile archive:
-#			less archive_file:contained_file>extracted_file
-#	   As less is not good for extracting raw data use instead:
-#			lesspipe.sh archive_file:contained_file>extracted_file
+#          LESSOPEN="|lesspipe.sh %s"; export LESSOPEN  (sh like shells)
+#          setenv LESSOPEN "|lesspipe.sh %s"            (csh, tcsh)
+#          Use the fully qualified path if lesspipe.sh is not in the search path
+#          View files in multifile archives:
+#                       less archive_file:contained_file
+#          This can be used to extract ASCII files from a multifile archive:
+#                       less archive_file:contained_file>extracted_file
+#          As less is not good for extracting raw data use instead:
+#                       lesspipe.sh archive_file:contained_file>extracted_file
 #          Even a file in a multifile archive that itself is contained in yet
 #          another archive can be viewed this way:
-#			less super_archive:archive_file:contained_file
-#	   Display the last file in the file1:..:fileN chain in raw format:
-#	   Suppress input filtering:	less file1:..:fileN:   (append a colon)
-#	   Suppress decompression:	less file1:..:fileN::  (append 2 colons)
+#                       less super_archive:archive_file:contained_file
+#          Display the last file in the file1:..:fileN chain in raw format:
+#          Suppress input filtering:    less file1:..:fileN:   (append a colon)
+#          Suppress decompression:      less file1:..:fileN::  (append 2 colons)
 #
 # Required programs and supported formats: see the separate file README
 # License: GPL (see file LICENSE)
@@ -52,8 +52,13 @@ filecmd() {
 }
 
 TMPDIR=${TMPDIR:-/tmp}
-sep=:						# file name separator
-altsep==					# alternate separator character
+
+# file name separator
+sep=:
+
+# alternate separator character
+altsep==
+
 if [[ -e "$1" && "$1" = *$sep* || "$1" = *$sep*$altsep* ]]; then
   sep=$altsep
   xxx="${1%=}"
@@ -132,7 +137,7 @@ filetype () {
   elif [[ "$type" = *Microsoft\ Office\ Document* && ("$name" = *.pp[st]) ]] ||
        [[ "$type" = *Microsoft\ Office\ PowerPoint* ]]; then
        return=" Microsoft PowerPoint Document"
-  elif [[ "$type" = *Microsoft\ Office\ Document* && ("$name" = *.xl[mst]) ]] || 
+  elif [[ "$type" = *Microsoft\ Office\ Document* && ("$name" = *.xl[mst]) ]] ||
        [[ "$type" = *Microsoft\ Excel* ]]; then
        return=" Microsoft Excel Document"
   elif [[ "$type" = *Microsoft\ Office\ Document* || "$type" = *Composite\ Document\ File\ V2* ]]; then
@@ -248,13 +253,13 @@ show () {
     if cmd_exist lsbom; then
       if [[ ! -f "$file1" ]]; then
         if [[ "$type" = *directory* ]]; then
-	  if [[ "$file1" = *.pkg ]]; then
-	    if [[ -f "$file1/Contents/Archive.bom" ]]; then
-	      type="bill of materials"
-	      file1="$file1/Contents/Archive.bom"
-	      msg "This is a Mac OS X archive directory, showing its contents (bom file)"
-	    fi
-	  fi
+          if [[ "$file1" = *.pkg ]]; then
+            if [[ -f "$file1/Contents/Archive.bom" ]]; then
+              type="bill of materials"
+              file1="$file1/Contents/Archive.bom"
+              msg "This is a Mac OS X archive directory, showing its contents (bom file)"
+            fi
+          fi
         fi
       fi
     fi
@@ -382,7 +387,7 @@ get_cmd () {
   rsave="$rest1"
   rest1="$rest2"
   if [[ "$file2" != "" ]]; then
-    if [[ "$1" = *\ tar* || "$1" = *\	tar* ]]; then
+    if [[ "$1" = *\ tar* || "$1" = *\   tar* ]]; then
       cmd=(istar "$2" "$file2")
     elif [[ "$1" = *Debian* ]]; then
       data="$(ar t "$2"|grep data.tar)"
@@ -574,7 +579,7 @@ isfinal() {
   if [[ $(tput colors) -ge 8 && ("$LESS" = *-*r* || "$LESS" = *-*R*) ]]; then
     COLOR="--color=always"
   else
-	COLOR="--color=auto"
+        COLOR="--color=auto"
   fi
   typeset t
   if [[ $3 = $sep$sep ]]; then
@@ -628,7 +633,7 @@ isfinal() {
     else
       "${cmd[@]}"
     fi
-  elif [[ "$1" = *\ tar* || "$1" = *\	tar* ]]; then
+  elif [[ "$1" = *\ tar* || "$1" = *\   tar* ]]; then
     msg "use tar_file${sep}contained_file to view a file in the archive"
     if [[ -n $COLOR ]] && cmd_exist tarcolor; then
       $tarcmd tvf "$2" | tarcolor
@@ -721,7 +726,7 @@ isfinal() {
     elif cmd_exist bsdtar; then
       msg "use rar_file${sep}contained_file to view a file in the archive"
       istemp "bsdtar tvf" "$2"
-    fi 
+    fi
   elif [[ "$1" = *7-zip\ archive* || "$1" = *7z\ archive* ]] && cmd_exist 7za; then
     typeset res
     res=$(istemp "7za l" "$2")

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -1169,10 +1169,10 @@ isfinal() {
     msg "append $sep to filename to view the encrypted file"
     gpg -d "$2"
 #endif
-#ifdef plutil
-  elif [[ "$1" = *Apple\ binary\ property\ list* ]] && cmd_exist plutil; then
+#ifdef plisutil
+  elif [[ "$1" = *Apple\ binary\ property\ list* ]] && cmd_exist plisutil; then
     msg "append $sep to filename to view the raw data"
-    plutil -convert xml1 -o - "$2"
+    plisutil -convert xml1 -o - "$2"
 #endif
   elif [[ "$1" = *data$NOL_A_P* ]]; then
     msg "append $sep to filename to view the raw data"

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -6,21 +6,21 @@
 #===============================================================================
 #
 # Usage:   lesspipe.sh is called when the environment variable LESSOPEN is set:
-#	   LESSOPEN="|lesspipe.sh %s"; export LESSOPEN	(sh like shells)
-#	   setenv LESSOPEN "|lesspipe.sh %s"		(csh, tcsh)
-#	   Use the fully qualified path if lesspipe.sh is not in the search path
-#	   View files in multifile archives:
-#			less archive_file:contained_file
-#	   This can be used to extract ASCII files from a multifile archive:
-#			less archive_file:contained_file>extracted_file
-#	   As less is not good for extracting raw data use instead:
-#			lesspipe.sh archive_file:contained_file>extracted_file
+#          LESSOPEN="|lesspipe.sh %s"; export LESSOPEN  (sh like shells)
+#          setenv LESSOPEN "|lesspipe.sh %s"            (csh, tcsh)
+#          Use the fully qualified path if lesspipe.sh is not in the search path
+#          View files in multifile archives:
+#                       less archive_file:contained_file
+#          This can be used to extract ASCII files from a multifile archive:
+#                       less archive_file:contained_file>extracted_file
+#          As less is not good for extracting raw data use instead:
+#                       lesspipe.sh archive_file:contained_file>extracted_file
 #          Even a file in a multifile archive that itself is contained in yet
 #          another archive can be viewed this way:
-#			less super_archive:archive_file:contained_file
-#	   Display the last file in the file1:..:fileN chain in raw format:
-#	   Suppress input filtering:	less file1:..:fileN:   (append a colon)
-#	   Suppress decompression:	less file1:..:fileN::  (append 2 colons)
+#                       less super_archive:archive_file:contained_file
+#          Display the last file in the file1:..:fileN chain in raw format:
+#          Suppress input filtering:    less file1:..:fileN:   (append a colon)
+#          Suppress decompression:      less file1:..:fileN::  (append 2 colons)
 #
 # Required programs and supported formats: see the separate file README
 # License: GPL (see file LICENSE)
@@ -53,8 +53,8 @@ filecmd() {
 }
 
 TMPDIR=${TMPDIR:-/tmp}
-sep=:						# file name separator
-altsep==					# alternate separator character
+sep=:                                           # file name separator
+altsep==                                        # alternate separator character
 # if the separator is part of the file name then altsep is used
 if [[ -e "$1" && "$1" = *$sep* || "$1" = *$sep*$altsep* ]]; then
   sep=$altsep
@@ -136,7 +136,7 @@ filetype () {
 elif [[ "$type" = *Microsoft\ Office\ Document* && ("$name" = *.pp[st]) ]] ||
   [[ "$type" = *Microsoft\ Office\ PowerPoint* ]]; then
 return=" Microsoft PowerPoint Document"
-  elif [[ "$type" = *Microsoft\ Office\ Document* && ("$name" = *.xl[mst]) ]] || 
+  elif [[ "$type" = *Microsoft\ Office\ Document* && ("$name" = *.xl[mst]) ]] ||
     [[ "$type" = *Microsoft\ Excel* ]]; then
   return=" Microsoft Excel Document"
 elif [[ "$type" = *Microsoft\ Office\ Document* || "$type" = *Composite\ Document\ File\ V2* ]]; then
@@ -253,13 +253,13 @@ show () {
     if cmd_exist lsbom; then
       if [[ ! -f "$file1" ]]; then
         if [[ "$type" = *directory* ]]; then
-	  if [[ "$file1" = *.pkg ]]; then
-	    if [[ -f "$file1/Contents/Archive.bom" ]]; then
-	      type="bill of materials"
-	      file1="$file1/Contents/Archive.bom"
-	      msg "This is a Mac OS X archive directory, showing its contents (bom file)"
-	    fi
-	  fi
+          if [[ "$file1" = *.pkg ]]; then
+            if [[ -f "$file1/Contents/Archive.bom" ]]; then
+              type="bill of materials"
+              file1="$file1/Contents/Archive.bom"
+              msg "This is a Mac OS X archive directory, showing its contents (bom file)"
+            fi
+          fi
         fi
       fi
     fi
@@ -403,7 +403,7 @@ get_cmd () {
   rsave="$rest1"
   rest1="$rest2"
   if [[ "$file2" != "" ]]; then
-    if [[ "$1" = *\ tar* || "$1" = *\	tar* ]]; then
+    if [[ "$1" = *\ tar* || "$1" = *\   tar* ]]; then
       set -A cmd istar "$2" "$file2"
     elif [[ "$1" = *Debian* ]]; then
       data="$(ar t "$2"|grep data.tar)"
@@ -422,7 +422,7 @@ get_cmd () {
 #elif rpmunpack,cpio
     elif [[ "$1" = *RPM* ]] && cmd_exist cpio && cmd_exist rpmunpack; then
       set -A cmd isrpm "$2" "$file2"
-#endif 
+#endif
 #ifdef fastjar
     elif [[ "$1" = *Jar\ archive* || "$1" = *Java\ archive* ]] && cmd_exist fastjar; then
       set -A cmd isjar "$2" "$file2"
@@ -430,7 +430,7 @@ get_cmd () {
 #ifdef unzip
     elif [[ "$1" = *Zip* || "$1" = *ZIP* || "$1" = *JAR* ]] && cmd_exist unzip; then
       set -A cmd istemp "unzip -avp" "$2" "$file2"
-#endif 
+#endif
 #ifdef unrar
     elif [[ "$1" = *RAR\ archive* ]]; then
       if cmd_exist unrar; then
@@ -446,7 +446,7 @@ get_cmd () {
 #elif bsdtar
     elif [[ "$1" = *RAR\ archive* ]] && cmd_exist bsdtar; then
       set -A cmd istemp "bsdtar Oxf" "$2" "$file2"
-#endif 
+#endif
 #ifdef 7za
     elif [[ "$1" = *7-zip\ archive* || "$1" = *7z\ archive* ]] && cmd_exist 7za; then
       set -A cmd istemp "7za e -so" "$2" "$file2"
@@ -459,7 +459,7 @@ get_cmd () {
 #ifdef cabextract
     elif [[ "$1" = *[Cc]abinet* ]] && cmd_exist cabextract; then
       set -A cmd iscab "$2" "$file2"
-#endif 
+#endif
     elif [[ "$1" = *\ ar\ archive* ]]; then
       set -A cmd istemp "ar p" "$2" "$file2"
 #ifdef isoinfo
@@ -652,7 +652,7 @@ isfinal() {
   if [[ $(tput colors) -ge 8 && ("$LESS" = *-*r* || "$LESS" = *-*R*) ]]; then
     COLOR="--color=always"
   else
-	COLOR="--color=auto"
+        COLOR="--color=auto"
   fi
   typeset t
   if [[ $3 = $sep$sep ]]; then
@@ -709,7 +709,7 @@ isfinal() {
     else
       "${cmd[@]}"
     fi
-  elif [[ "$1" = *\ tar* || "$1" = *\	tar* ]]; then
+  elif [[ "$1" = *\ tar* || "$1" = *\   tar* ]]; then
     msg "use tar_file${sep}contained_file to view a file in the archive"
 #ifdef tarcolor
     if [[ -n $COLOR ]] && cmd_exist tarcolor; then
@@ -855,7 +855,7 @@ isfinal() {
     elif cmd_exist bsdtar; then
       msg "use rar_file${sep}contained_file to view a file in the archive"
       istemp "bsdtar tvf" "$2"
-    fi 
+    fi
 #elif rar
   elif [[ "$1" = *RAR\ archive* ]] && cmd_exist rar; then
     msg "use rar_file${sep}contained_file to view a file in the archive"
@@ -934,7 +934,7 @@ isfinal() {
   elif [[ "$1" = *\ DVI* ]] && cmd_exist dvi2tty; then
     msg "append $sep to filename to view the raw DVI file"
     isdvi "$2"
-#endif 
+#endif
   elif [[ "$PARSEHTML" = yes && "$1" = *HTML$NOL_A_P* ]]; then
     msg "append $sep to filename to view the HTML source"
     parsehtml "$2"
@@ -1066,12 +1066,12 @@ isfinal() {
   elif [[ "$1" = *Excel\ 2007* ]] && cmd_exist git-xlsx-textconv.pl; then
     msg "append $sep to filename to view the spreadsheet source"
     git-xlsx-textconv.pl "$2"
-#endif 
+#endif
 #ifdef git-xlsx-textconv
   elif [[ "$1" = *Excel\ 2007* ]] && cmd_exist git-xlsx-textconv; then
     msg "append $sep to filename to view the spreadsheet source"
     git-xlsx-textconv "$2"
-#endif 
+#endif
 #ifdef pptx2md
   elif [[ "$1" = *PowerPoint\ 2007* ]] && cmd_exist pptx2md; then
     msg "append $sep to filename to view the PowerPoint source"
@@ -1112,7 +1112,7 @@ isfinal() {
   elif [[ "$PARSEHTML" = yes && "$1" = *Microsoft\ Excel\ Document* ]] && cmd_exist xlhtml; then
     msg "append $sep to filename to view the spreadsheet source"
     xlhtml -te "$2" | parsehtml -
-#endif 
+#endif
 #ifdef ppthtml
   elif [[ "$PARSEHTML" = yes && "$1" = *Microsoft\ PowerPoint\ Document* ]] && cmd_exist ppthtml; then
     msg "append $sep to filename to view the PowerPoint source"
@@ -1147,7 +1147,7 @@ isfinal() {
       echo "================================= Content ======================================"
       isoinfo -lR"$joliet" -i "$2"
     fi
-#endif 
+#endif
 #ifdef lsbom
   elif [[ "$1" = *bill\ of\ materials* ]] && cmd_exist lsbom; then
     msg "append $sep to filename to view the raw data"
@@ -1192,7 +1192,7 @@ isfinal() {
   elif [[ "$1" = "image" ]] && cmd_exist identify; then
     msg "append $sep to filename to view the raw data"
     identify -verbose "$2"
-#endif 
+#endif
 #ifdef id3v2
   elif [[ "$1" = "mp3" ]]; then
     if cmd_exist id3v2; then
@@ -1213,7 +1213,7 @@ isfinal() {
   elif [[ "$1" = "mp3" ]] && cmd_exist mp3info; then
     msg "append $sep to filename to view the raw data"
     mp3info "$2"
-#endif 
+#endif
 #ifdef mediainfo
   elif [[ "$1" = "image" || "$1" = "mp3" || "$1" = "audio" || "$1" = "video" ]] && cmd_exist mediainfo; then
     msg "append $sep to filename to view the raw data"
@@ -1222,7 +1222,7 @@ isfinal() {
   elif [[ "$1" = "image" || "$1" = "mp3" || "$1" = "audio" || "$1" = "video" ]] && cmd_exist exiftool; then
     msg "append $sep to filename to view the raw data"
     exiftool "$2"
-#endif 
+#endif
   fi
 
   if [[ "$1" = *text* ]]; then

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -53,14 +53,20 @@ filecmd() {
 }
 
 TMPDIR=${TMPDIR:-/tmp}
-sep=:                                           # file name separator
-altsep==                                        # alternate separator character
+
+# file name separator
+sep=:
+
+# alternate separator character
+altsep==
+
 # if the separator is part of the file name then altsep is used
 if [[ -e "$1" && "$1" = *$sep* || "$1" = *$sep*$altsep* ]]; then
   sep=$altsep
   xxx="${1%=}"
   set "$xxx"
 fi
+
 tmpdir="$TMPDIR"/lesspipe."$RANDOM"
 mkdir "$tmpdir"
 
@@ -403,7 +409,7 @@ get_cmd () {
   rsave="$rest1"
   rest1="$rest2"
   if [[ "$file2" != "" ]]; then
-    if [[ "$1" = *\ tar* || "$1" = *\   tar* ]]; then
+    if [[ "$1" = *\ tar* || "$1" = *\ tar* ]]; then
       set -A cmd istar "$2" "$file2"
     elif [[ "$1" = *Debian* ]]; then
       data="$(ar t "$2"|grep data.tar)"
@@ -709,7 +715,7 @@ isfinal() {
     else
       "${cmd[@]}"
     fi
-  elif [[ "$1" = *\ tar* || "$1" = *\   tar* ]]; then
+  elif [[ "$1" = *\ tar* || "$1" = *\ tar* ]]; then
     msg "use tar_file${sep}contained_file to view a file in the archive"
 #ifdef tarcolor
     if [[ -n $COLOR ]] && cmd_exist tarcolor; then

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -976,13 +976,13 @@ isfinal() {
     msg "append $sep to filename to view the DjVu source"
     djvutxt "$2"
 #endif
-#ifdef docx2txt.pl
+#ifdef docx2txt
   elif [[ "$1" = *Microsoft\ Word\ 2007* ]]; then
-    if cmd_exist docx2txt.pl; then
+    if cmd_exist docx2txt; then
       msg "append $sep to filename to view the raw word document"
-      docx2txt.pl "$2" -
+      docx2txt "$2" -
     else
-      msg "install docx2txt.pl to view human readable text"
+      msg "install docx2txt to view human readable text"
       cat "$2"
     fi
 #elif doc2txt.pl

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -1169,10 +1169,10 @@ isfinal() {
     msg "append $sep to filename to view the encrypted file"
     gpg -d "$2"
 #endif
-#ifdef plisutil
-  elif [[ "$1" = *Apple\ binary\ property\ list* ]] && cmd_exist plisutil; then
+#ifdef plistutil
+  elif [[ "$1" = *Apple\ binary\ property\ list* ]] && cmd_exist plistutil; then
     msg "append $sep to filename to view the raw data"
-    plisutil -convert xml1 -o - "$2"
+    plistutil -convert xml1 -o - "$2"
 #endif
   elif [[ "$1" = *data$NOL_A_P* ]]; then
     msg "append $sep to filename to view the raw data"


### PR DESCRIPTION
- Use `docx2txt` instead of `docx2txt.pl` by default: (https://repology.org/project/docx2txt/versions)

- Use `plistutil` instead of `plutil` by default. Latter is an OSX app.name, while former is the part of `libplist`: https://repology.org/project/libplist/versions

- Misc. formatting and clean-up.