### PR TITLE
quote tr arguments

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -48,7 +48,7 @@ fi
 
 filecmd() {
   file -L -s "$@"
-  file -L -s -i "$@" 2> /dev/null | sed -n 's/.*charset=/;/p' | tr [:lower:] [:upper:]
+  file -L -s -i "$@" 2> /dev/null | sed -n 's/.*charset=/;/p' | tr '[:lower:]' '[:upper:]'
 }
 
 TMPDIR=${TMPDIR:-/tmp}

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -49,7 +49,7 @@ fi
 
 filecmd() {
   file -L -s "$@"
-  file -L -s -i "$@" 2> /dev/null | sed -n 's/.*charset=/;/p' | tr [:lower:] [:upper:]
+  file -L -s -i "$@" 2> /dev/null | sed -n 's/.*charset=/;/p' | tr '[:lower:]' '[:upper:]'
 }
 
 TMPDIR=${TMPDIR:-/tmp}


### PR DESCRIPTION
without the quotes I get a warning:

```
$ bash -c 'echo a | tr [:lower:] [:upper:]'
tr: misaligned [:upper:] and/or [:lower:] construct
```