### PR TITLE
Fix parsehtml

### DIFF
--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -243,7 +243,23 @@ show () {
   rest2="${rest11#$file2}"
   rest11="$rest1"
 
-  if cmd_exist html2text || cmd_exist elinks || cmd_exist links || cmd_exist lynx || cmd_exist w3m; then
+  if false \
+#ifdef html2text
+  || cmd_exist html2text \
+#endif
+#ifdef elinks
+  || cmd_exist elinks \
+#endif
+#ifdef links
+  || cmd_exist links \
+#endif
+#ifdef lynx
+  || cmd_exist lynx \
+#endif
+#ifdef w3m
+  || cmd_exist w3m
+#endif
+  ;then
     PARSEHTML=yes
   else
     PARSEHTML=no
@@ -610,6 +626,7 @@ parsehtml () {
       html2text -from_encoding utf-8
     else html2text -utf8 "$1" 2>/dev/null ||
       html2text -from_encoding utf-8 "$1"; fi
+#endif
 #ifdef lynx
   elif cmd_exist lynx; then
     if [[ "$1" = - ]]; then set - -stdin; fi

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -257,7 +257,7 @@ show () {
   || cmd_exist lynx \
 #endif
 #ifdef w3m
-  || cmd_exist w3m
+  || cmd_exist w3m \
 #endif
   ;then
     PARSEHTML=yes


### PR DESCRIPTION
If lesspipe is configured to not use a specific html back end but the back end is still installed and found on the system
then HTML parsing will still be used. 

Steps to reproduce:
(1) configure lesspipe without html2text, links, elinks, lynx and w3m
(2) have a executable called html2text (or any other of the above installed)
(3) run lesspipe on some pdf for example

Expected behavior: PARSEHTML should be 'no' as all HTML back ends are disabled 
Actual behavior: PARSHTML is actually set to yes by the pure presence of a binary. Further pdf parsing fails as all HTML parsers have been removed. 

The motivation for this commit is to help with [this issue](https://github.com/wofr06/lesspipe/issues/60).
This commit should allow for the save removal of html2text while still having it installed on a system.