### PR TITLE
Revert colorization changes in v1.89 to 1.88 functionality.

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -176,6 +176,9 @@ fi
 if [[ -n "$return" ]]; then
   echo "$return"
   return
+elif [[ -n "$type" ]]; then
+  echo "$type"
+  return
 fi
 
 mime="$(file --mime "$1" | cut -d : -f 2-)"

--- a/lesspipe.sh.in
+++ b/lesspipe.sh.in
@@ -178,6 +178,9 @@ fi
 if [[ -n "$return" ]]; then
   echo "$return"
   return
+elif [[ -n "$type" ]]; then
+  echo "$type"
+  return
 fi
 
 # file -b not supported by all versions of 'file'


### PR DESCRIPTION
_Deferred return from filetype() of filecmd output means file --mime
type sometimes overrides it.  This breaks some simple uses like
compressed text files and numerous test cases.  Revert this change
until the colorization (issue#55) can be addressed without impacting
other cases._

This commit eliminates all test case failures on Debian and all but 4 on MacOS.  It addresses issue #61.
On both v1.88 and v1.90 plus this commit 678f794:
 - Debian 10: 32/9/0 tests passed/ignored/failed in 7 seconds
 - MacOS Catalina: 25/12/4 tests passed/ignored/failed in 6 seconds

However, on v1.90:
 - Debian 10: 14/10/17 tests passed/ignored/failed in 22 seconds
 - MacOS Catalina: 12/14/15 tests passed/ignored/failed in 8 seconds

I suggest that the colorization work add some test cases to validate its behavior, so that regressions can be more easily detected and avoided.