### PR TITLE
Consider also `lessfilter` in user PATH

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -756,11 +756,10 @@ if [[ -z "$1" ]]; then
 		echo "export LESSOPEN"
 	fi
 else
-	if [ -x ~/.lessfilter ]; then
-		~/.lessfilter "$1"
-		if [ $? -eq 0 ]; then
-			exit 0
-		fi
+	if [ -x "${HOME}/.lessfilter" ]; then
+		"${HOME}/.lessfilter" "$1" && exit 0
+	elif has_cmd lessfilter; then
+		lessfilter "$1" && exit 0
 	fi
 	show "$@"
 fi


### PR DESCRIPTION
In order to not pollute their homedir, many users don't like to drop
all sort of configs/binaries like hidden `.lessfilter` into their home.

One way to support a user custom `lessfilter`, is looking if that's
available in their PATH, e.g. `~/bin/` or `~/.local/bin/`. This would
also give the possibility to get the `lessfilter` as a shell plugin,
without messing user's homedir.

This adds support for that, but still giving priority to `~/.lessfilter`
when found.