### PR TITLE
vimcolor: Use #!/usr/bin/env perl

### DIFF
--- a/vimcolor
+++ b/vimcolor
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Syntax highlight text using Vim
 # simplified version to use it as a monolithic function within lesspipe


### PR DESCRIPTION
This is consistent with the other perl scripts, and required on systems like NixOS where perl is not in /usr/bin.