### PR TITLE
Run test suite in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: "Test suite"
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  test-suite:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get -q update
+          sudo apt-get install --no-install-recommends -qy \
+            brotli \
+            cabextract \
+            csvkit \
+            djvulibre-bin \
+            genisoimage \
+            ghostscript \
+            gnupg \
+            groff \
+            hdf5-tools \
+            id3v2 \
+            less \
+            libarchive-tools \
+            libreoffice \
+            locales-all \
+            lz4 \
+            lzip \
+            mediainfo \
+            p7zip \
+            pandoc \
+            poppler-utils \
+            python3-pygments \
+            rpm \
+            source-highlight \
+            texlive-binaries \
+            unrar \
+            unrtf \
+            vim
+
+      - name: Run test suite
+        run: TERM=ansi ./test.pl -e


### PR DESCRIPTION
This currently ignores 13 tests and fails 4.

```
40 ignore  iso9660 contents (needs isoinfo,!bsdtar)
41 ignore  (on the fly) (needs isoinfo,!bsdtar)
42 ignore  extract file from iso9660 (needs isoinfo,!bsdtar)
43 ignore  (on the fly) (needs isoinfo,!bsdtar)
58 ignore  html text (needs html_converter)
62 ignore  java class file (needs procyon)
64 ignore  pptx (neu) (needs pptx2md,mdcat|pptx2md,pandoc|libreoffice,html_converter)
67 ignore  odp (needs libreoffice,html_converter)
68 ignore  ods (needs xlscat|libreoffice,html_converter)
70 ignore  ppt (old), catppt not always working (needs libreoffice,html_converter)
72 NOT ok  openoffice1 (very old) 
82 ignore  matlab git #18 (needs matdump)
83 ignore  matlab, not recognized by file (needs matdump)
86 ignore  Apple binary property list (needs plistutil)
87 NOT ok  mp3 without mp3 extension 
90 NOT ok  directory 
100 NOT ok  Jupyter notebook to rst git #6 
```

https://github.com/andersk/lesspipe/runs/7187632389