### PR TITLE
Fix failing tests in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,11 @@ jobs:
             id3v2 \
             less \
             libarchive-tools \
+            libimage-exiftool-perl \
             libreoffice \
             locales-all \
             lz4 \
             lzip \
-            mediainfo \
             p7zip \
             pandoc \
             poppler-utils \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,4 +48,7 @@ jobs:
             vim
 
       - name: Run test suite
-        run: TERM=ansi ./test.pl -e
+        run: |
+          export TERM=ansi
+          eval "$(dircolors -b)"
+          ./test.pl -e

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -97,6 +97,8 @@ filetype () {
 				ftype=pgp ;;
 			Audio\ file\ with\ ID3\ *)
 				ftype=mp3 ;;
+			'OpenOffice.org 1.x Writer document')
+				ftype=ooffice1 ;;
 			# if still unspecific, determine file type by extension
 			data)
 				### binary only file formats, type not guessed by 'file'

--- a/test.pl
+++ b/test.pl
@@ -422,7 +422,7 @@ less tests/filter.tgz:test.pod:pod	# unmodified pod text, colorized, needs pod2t
 c =head1
 less tests/filter.tgz:test_plain:sh	# plain text, force color (shellscript)
 c test
-less tests/filter.tgz:index.rst		# Jupyter notebook to rst git #6, needs mdcat|pandoc
+less tests/filter.tgz:index.rst		# reStructuredText, needs mdcat
 c # test
 less tests/filter.tgz:test.json		# json, epub and ipynb also covered git #62 (fails if no syntax/json.vim), needs pandoc
 c false

--- a/test.pl
+++ b/test.pl
@@ -395,7 +395,7 @@ less tests/filter.tgz:test.pem		# SSL related files git #15
 less tests/filter.tgz:test.bplist	# Apple binary property list, needs plistutil
 ~ <dict>
 ###    no test case for decoding gpg/pgp encrypted files git #12
-less tests/filter.tgz:test_mp3		# mp3 without mp3 extension, needs mediainfo|exiftools
+less tests/filter.tgz:test_mp3		# mp3 without mp3 extension, needs exiftool, not mediainfo
 ~ Title .* test
 less tests/filter.tgz:test_mp3:mp3	# mp3, needs id3v2
 ~ Title  : test .*


### PR DESCRIPTION
* ci: Run test suite with dircolors loaded

  This is needed for `test.jar` to be colored in the directory test.

* Fix mp3 without extension test

  `mediainfo` requires a seekable file, so it cannot work with stdin from `tar Ox`.

* Require `mdcat` for rst test

  `pandoc` does not colorize the word “test”. Also, this test has nothing to do with Jupyter notebooks, so give it an accurate description.

* Fix openoffice1 test on Ubuntu 20.04

  On Ubuntu 20.04, `file --mime` doesn’t recognize this file but `file` does.

  ```console
  $ tar Oxf tests/filter.tgz test_ooffice1 | file --mime -
  /dev/stdin: application/octet-stream; charset=binary
  $ tar Oxf tests/filter.tgz test_ooffice1 | file -
  /dev/stdin: OpenOffice.org 1.x Writer document
  ```
