### PR TITLE
Fix build for macOS Homebrew

### DIFF
--- a/configure
+++ b/configure
@@ -33,7 +33,7 @@ my $bash_complete_dir = `pkg-config --variable=completionsdir bash-completion`;
 $bash_complete_dir ||= '/usr/share/bash-completion/completions';
 # dynamic loading not working, use the following dir instead:
 $bash_complete_dir = '/etc/bashcompletion.d';
-if ($opt_prefix and $opt_prefix !~ /^\/usr/) {
+if ( $opt_prefix ) {
 	$bash_complete_dir = "$ENV{HOME}/.local/share/bash-completion";
 	# dynamic loading not working, use the following dir instead:
 	$bash_complete_dir = "$opt_prefix/share/bash-completion";


### PR DESCRIPTION
### Description

v2.06 does [not build](https://github.com/Homebrew/homebrew-core/pull/108277) with Homebrew on Intel Macs, due to [this line](https://github.com/wofr06/lesspipe/blob/69f0c99a660c53c0cba9e0e18961653f919f7bbd/configure#L36) which was addeded in [this commit](https://github.com/wofr06/lesspipe/commit/5c51ebdb2eadf96387a9974f01c301578dea2ce4). I'm not sure what the purpose of the second condition is, but it seems to force any prefix beginning with `/usr` to `/usr/local` instead. This is problematic for homebrew, which by default installs to `/usr/local/Cellar/{formula}/{version}` on Intel macOS.
