### PR TITLE
Fix vimcolor hang due to wrong vim CLI arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 ****************************************************************************
 # ChangeLog for lesspipe.sh						   #
 ****************************************************************************
+- fix vimcolor hang due to wrong vim CLI arguments
 Version 2.07 Jan 10 2023
 - man page updates
 - support for displaying mail messages

--- a/vimcolor
+++ b/vimcolor
@@ -202,7 +202,7 @@ EOF
 
 	run(
 		$defaults->{vim_command},
-		$defaults->{vim_options},
+		@{$defaults->{vim_options}},
 		$filename, ('-s' => "$script_file")
 	);
 


### PR DESCRIPTION
Using `vimcolor` on my system causes a hang on the following command:

```bash
vim ARRAY(0x123456789abc) ...
```

The list of Vim CLI options are stored in an array reference, which
would stringify to "ARRAY(0x123456789abc)" or similar if not
dereferenced before passing it to the vim binary.

Alternatively, the `run()` subroutine could be modified to dereference the CLI
options passed that are passed as an array reference. Let me know if you prefer
that approach.

Please review and merge, or let me know how to improve it!

## Additional notes

I noticed that the tests are failing locally due to test 106 hanging, but they
are passing in GitHub Actions. Also the tests are picking up my system's
`vimcolor` script instead of the modified script from the cloned repository.

I played around with the tests in my fork, but couldn't reproduce the issue in
GitHub Actions yet. Let me know if you would like to track those issues down as
well, and need more information.