### PR TITLE
Use mandoc if groff is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ the author by email.
 
 ### 4.2 List of preprocessed file types
 - directory		displayed using `ls -lA`
-- nroff(man)		requires `groff`
+- nroff(man)		requires `groff` or `mandoc`
 - shared library	requires `nm`
 - MS Word (doc)		requires `wvText` or `antiword` or `catdoc` or `libreoffice`
 - Powerpoint (ppt)	requires `catppt`

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -535,6 +535,8 @@ isfinal () {
 				[[ "$fext" == me ]] && macro=e
 				[[ "$fext" == ms ]] && macro=s
 				cmd=(groff -s -p -t -e -Tutf8 -m "$macro" "$1")
+			elif has_cmd mandoc; then
+				cmd=(mandoc "$1")
 			fi ;;
 		rtf)
 			{ has_cmd unrtf && cmd=(istemp "unrtf --text" "$1"); } ||

--- a/test.pl
+++ b/test.pl
@@ -369,7 +369,7 @@ less tests/filter.tgz:test_xls		# xls (old), needs in2csv|xls2csv|libreoffice,ht
 = test
 less tests/filter.tgz:test_ooffice1	# openoffice1 (very old), needs sxw2txt|libreoffice
 = test
-less tests/filter.tgz:test_nroff	# man pages etc (nroff), needs groff
+less tests/filter.tgz:test_nroff	# man pages etc (nroff), needs groff|mandoc
 ~ .* test \(1\)
 less tests/filter.tgz:test_rtf		# rtf, needs unrtf|libreoffice
 ~ test


### PR DESCRIPTION
macOS and *BSD systems have mandoc(1).  It detects the encoding and macro language automatically, so I think no option is required.