### PR TITLE
Fix command execution when there are environment overrides

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -594,11 +594,17 @@ isfinal () {
 		msg "$msg"
 	fi
 	if [[ -n ${cmd[*]} ]]; then
+		# TAU: When cmd starts with environment variable settings, bash will refuse to execute it via : "${cmd[@]}"
+		# The remedy is simple : Just run it through the "env" command in that case.
+	  if [[ "$cmd" =~ '=' ]]; then
+			cmd=(env "${cmd[@]}")
+		fi
 		if [[ ${colorizer[*]} == archive_color && $COLOR == *always ]]; then
 			"${cmd[@]}" | archive_color
 		else
 			"${cmd[@]}"
 		fi
+
 	else
 		[[ -n "$file2" ]] && fext="$file2"
 		[[ $fcat == text && $x != plain ]] && fext=$x
@@ -805,4 +811,3 @@ else
 	fi
 	show "$@"
 fi
-


### PR DESCRIPTION

## ISSUE DESCRIPTION

`lesspipe.sh` builds the filter command (with its options/args) in a bash array (cmd) which then gets executed like below:

```bash
"${cmd[@]}"
```
This approach appears to work as long as there are no environment overrides, like so : 
```bash 
ls -lA -G ~/
```
But `bash` refuses such an invocation  when there are preceding environment overrides, like so : 

```bash
CLICOLOR_FORCE=1 ls -lA -G ~/
```
On my machine (macOS), `lesspipe.sh` was trying to invoke that very command when doing `less ~/`.
Instead of a directory listing, I was getting an error from bash, along the lines of `CLICOLOR_FORCE=1 : Command not found` 

Note that, though on macOS, I am running a relatively recent version of `bash` (5.x).

## PROPOSED FIX
Just prepend the  `env` command in this case, like so :  

```bash
if [[ "$cmd" =~ '=' ]]; then   # first element contains an equal sign ?
  cmd=(env "${cmd[@]}")
fi
```
## NOTE

Both the issue and the proposed fix may independently be checked in an interactive bash shell, as below :

```bash
$ cmd=(echo "Hello World")     ; "${cmd[@]}"   # OK
# Hello World

$ cmd=(SOME_VAR=1 echo "Hello World")       ; "${cmd[@]}"   # NOK, bash complains
# -bash: SOME_VAR=1: command not found

$ cmd=(env SOME_VAR=1 echo "Hello World") ; "${cmd[@]}"   # OK, fixed
# Hello World


```









