### PR TITLE
Add support for Device Tree Blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ the author by email.
 - MacOS X plist		requires `plistutil`
 - binary data		requires `strings`
 - json			requires `jq`
+- Device Tree Blobs(DTB)	requires `dtc`
 
 To show the unmodified html, xml or perl pod text, append a colon to the file
 name. Appending in addition the file type (html, xml, pod) produces a colored
@@ -415,6 +416,7 @@ filtering for certain file types.
 - wvText               https://github.com/AbiWord/wv/ (2014)
 - xlscat               https://metacpan.org/pod/Spreadsheet::Read (2023)
 - sxw2txt              https://vinc17.net/software/sxw2txt (2015)
+- dtc                  https://git.kernel.org/cgit/utils/dtc/dtc.git (2023)
 
 ### 11.2 References
 - [1] http://www.greenwoodsoftware.com/less/	(less)

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -172,6 +172,11 @@ contentline () {
 	echo "$a Contents $a"
 }
 
+warrningsline () {
+	declare a="==================================="
+	echo "$a Warnings $a"
+}
+
 nexttmp () {
 	declare new="$tmpdir/lesspipe.$RANDOM"
 	echo "$new"
@@ -479,7 +484,7 @@ isfinal () {
 		html|xml)
 			[[ -z $file2 ]] && has_htmlprog && cmd=(ishtml "$1") ;;
 		dtb)
-			has_cmd dtc && cmd=(dtc -I dtb -O dts -qqq -o - -- "$1") ;;
+			has_cmd dtc && cmd=(isdtb "$1") ;;
 		pdf)
 			{ has_cmd pdftotext && cmd=(istemp pdftotext -layout -nopgbrk -q -- "$1" -); } ||
 			{ has_cmd pdftohtml && has_htmlprog && cmd=(istemp ispdf "$1"); } ||
@@ -736,6 +741,13 @@ isoffice () {
 
 isoffice2 () {
 	istemp "libreoffice --headless --cat" "$1" 2>/dev/null
+}
+
+isdtb () {
+	errors=$(nexttmp)
+	dtc -I dtb -O dts -o - -- $1 2> "$errors"
+	warrningsline
+	cat "$errors"
 }
 
 has_htmlprog () {

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -744,8 +744,10 @@ isoffice2 () {
 }
 
 isdtb () {
+	out=$(nexttmp)
 	errors=$(nexttmp)
-	dtc -I dtb -O dts -o - -- $1 2> "$errors"
+	dtc -I dtb -O dts -o - -- $1 1>"$out" 2> "$errors"
+	has_colorizer "$out" "dts" && "${colorizer[@]}" || cat "$out"
 	warrningsline
 	cat "$errors"
 }

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -746,8 +746,8 @@ isoffice2 () {
 isdtb () {
 	out=$(nexttmp)
 	errors=$(nexttmp)
-	dtc -I dtb -O dts -o - -- $1 1>"$out" 2> "$errors"
-	has_colorizer "$out" "dts" && "${colorizer[@]}" || cat "$out"
+	dtc -I dtb -O dts -o - -- "$1" 1>"$out" 2> "$errors"
+	cat "$out"
 	warrningsline
 	cat "$errors"
 }

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -107,6 +107,8 @@ filetype () {
 				ftype=ooffice1 ;;
 			*osascript*)
 				ftype=applescript ;;
+			*Device\ Tree\ Blob*)
+				ftype=dtb ;;
 			# if still unspecific, determine file type by extension
 			data)
 				### binary only file formats, type not guessed by 'file'
@@ -476,6 +478,8 @@ isfinal () {
 			msg="$x: showing the output of ${cmd[*]}" ;;
 		html|xml)
 			[[ -z $file2 ]] && has_htmlprog && cmd=(ishtml "$1") ;;
+		dtb)
+			has_cmd dtc && cmd=(dtc -I dtb -O dts -qqq -o - -- "$1") ;;
 		pdf)
 			{ has_cmd pdftotext && cmd=(istemp pdftotext -layout -nopgbrk -q -- "$1" -); } ||
 			{ has_cmd pdftohtml && has_htmlprog && cmd=(istemp ispdf "$1"); } ||


### PR DESCRIPTION
Device Tree Blob is a binary format used by Linux kernel to represent [Device Trees]( https://en.wikipedia.org/wiki/Devicetree). It could be converted into a human-readable text using [device tree compiler or dtc for short](https://git.kernel.org/cgit/utils/dtc/dtc.git). 

Use dtc to show DTB in a human-readable form. Any errors/warnings produced by dtc during conversion are appended to the dtc output.