### PR TITLE
PEM certificate is crt/x509 not csr

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -98,7 +98,7 @@ filetype () {
 			*PEM\ certificate\ request)
 				ftype=csr ;;
 			*PEM\ certificate)
-				ftype=csr ;;
+				ftype=x509 ;;
 			*Microsoft\ OOXML)
 				ftype=docx ;;
 			Apple\ binary\ property\ list)


### PR DESCRIPTION
Originally I have change ftype to crt but it was not displayed properly and I saw that extension .crt has ftype x509 so I used that type.

This bug is introduced by https://github.com/wofr06/lesspipe/commit/4469ce3a307b025b37d26869b9d49a8fe2d7ffc2#diff-1d1c7e00b6f9694b32709c3c2f27ce31a59fb99df5ebfd476c5b93206bd3c329