### PR TITLE
Fix usage instructions for bourne shell (sh/bash).

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ the author by email.
  The command to set **LESSOPEN** can also be displayed by calling `lesspipe.sh`
  without arguments. This can even be used to set **LESSOPEN** directly:
 ```
-        eval lesspipe.sh                  # (bash) or
+        eval "$(lesspipe.sh)"             # (bash) or
         lesspipe.sh | source /dev/stdin   # (zsh)
 ```
  As `lesspipe.sh` is accepting only a single argument, a hierarchical list of file


### PR DESCRIPTION
The fix is self-evident as a matter of syntax. With the previous instruction to `eval lesspipe.sh`, the shell will execute `lesspipe.sh` but simply echo its result to stdout. To set `LESSOPEN` the output needs to be eval'd, so capture it with the shell's $() command substitution.

Demonstration:

```
$ unset LESSOPEN
$ eval lesspipe.sh
LESSOPEN="|/usr/bin/lesspipe.sh %s"
export LESSOPEN
$ echo $LESSOPEN

$ eval "$(lesspipe.sh)"
$ echo $LESSOPEN
|/usr/bin/lesspipe.sh %s
```

Tested with GNU bash, version 5.1.16 (and a busybox `sh`).