### PR TITLE
Add support for pygmentize's -P option

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -457,7 +457,7 @@ has_colorizer () {
 			opt+=("$COLOR" --paging=never "$1") ;;
 		pygmentize)
 			pygmentize -l "$lang" /dev/null &>/dev/null && opt=(-l "$lang") || opt=(-g)
-			[[ -n $LESSCOLORIZER && $LESSCOLORIZER = *-O\ *style=* ]] && style="${LESSCOLORIZER/*style=/}"
+			[[ -n $LESSCOLORIZER && $LESSCOLORIZER = *-O\ *style=* || $LESSCOLORIZER = *-P\ style=* ]] && style="${LESSCOLORIZER/*style=/}"
 			[[ -n $style ]] && opt+=(-O style="${style%% *}")
 			[[ $colors -ge 256 ]] && opt+=(-f terminal256)
 			[[ "$1" == - ]] || opt+=("$1") ;;


### PR DESCRIPTION
pygmentize's -P flag allows for specifying a single option, rather than a comma separated list, otherwise it works pretty much like -O