### PR TITLE
Fix `bat` colorization and robust config file detection

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -453,7 +453,8 @@ has_colorizer () {
 				[[ -z $style ]] && style=plain
 				[[ -z $theme ]] && theme=ansi
 			fi
-			opt+=(--style="${style%% *}" --theme="${theme%%[|&;<>]*}")
+			[[ -n $style ]] && opt+=(--style="${style%% *}")
+			[[ -n $theme ]] && opt+=(--theme="${theme%%[|&;<>]*}")
 			opt+=("$COLOR" --paging=never "$1") ;;
 		pygmentize)
 			pygmentize -l "$lang" /dev/null &>/dev/null && opt=(-l "$lang") || opt=(-g)

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -437,7 +437,7 @@ has_colorizer () {
 	[[ -n $3 ]] && lang=$3 || lang=$2
 	case $prog in
 		bat|batcat)
-		        batconfig=$(bat --config-file)
+		        batconfig=$($prog --config-file)
 			[[ -n $lang ]] && $prog --list-languages|sed 's/.*:/,/;s/$/,/'|grep -i ",$lang," > /dev/null && opt=(-l "$lang")
 			[[ -n $LESSCOLORIZER && $LESSCOLORIZER = *\ *--style=* ]] && style="${LESSCOLORIZER/* --style=/}"
 			[[ -z $style ]] && style=$BAT_STYLE

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -454,8 +454,8 @@ has_colorizer () {
 				[[ -z $style ]] && style=plain
 				[[ -z $theme ]] && theme=ansi
 			fi
-			[[ -n $style ]] && opt+=(--style="${style%% *}")
-			[[ -n $theme ]] && opt+=(--theme="${theme%%[|&;<>]*}")
+			style="${style%% *}" theme="${theme%%[|&;<>]*}"
+			opt+=(${style:+--style="$style"} ${theme:+--theme="$theme"})
 			opt+=("$COLOR" --paging=never "$1") ;;
 		pygmentize)
 			pygmentize -l "$lang" /dev/null &>/dev/null && opt=(-l "$lang") || opt=(-g)

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -437,17 +437,18 @@ has_colorizer () {
 	[[ -n $3 ]] && lang=$3 || lang=$2
 	case $prog in
 		bat|batcat)
+		        batconfig=$(bat --config-file)
 			[[ -n $lang ]] && $prog --list-languages|sed 's/.*:/,/;s/$/,/'|grep -i ",$lang," > /dev/null && opt=(-l "$lang")
 			[[ -n $LESSCOLORIZER && $LESSCOLORIZER = *\ *--style=* ]] && style="${LESSCOLORIZER/* --style=/}"
 			[[ -z $style ]] && style=$BAT_STYLE
 			[[ -n $LESSCOLORIZER && $LESSCOLORIZER = *\ *--theme=* ]] && theme="${LESSCOLORIZER/* --theme=/}"
 			[[ -z $theme ]] && theme=$BAT_THEME
-			if [[ -r "$HOME/.config/bat/config" ]]; then
+			if [[ -r "$batconfig" ]]; then
 				if [[ -z $style ]]; then
-					grep -q -e '^--style' "$HOME/.config/bat/config" || style=plain
+					grep -q -e '^--style' "$batconfig" || style=plain
 				fi
 				if [[ -z $theme ]]; then
-					grep -q -e '^--theme' "$HOME/.config/bat/config" || theme=ansi
+					grep -q -e '^--theme' "$batconfig" || theme=ansi
 				fi
 			else
 				[[ -z $style ]] && style=plain


### PR DESCRIPTION
- Fix bat colorize when no `--style`/`--theme` is detected
- Use `bat --config-file` for more robustness

### Additional Remarks

re: config file issue: the location of the config file is platform dependent, it can also be set to a custom location by setting an environment variable.  So instead of trying to guess, follow [upstream recommendation](https://github.com/sharkdp/bat?tab=readme-ov-file#configuration-file)