### PR TITLE
Add `./configure` to make process.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -16,6 +16,7 @@ Execute the following commands (for a more detailed description see below):
 
 or if you prefer make:
 
+  ./configure
   make
   make test
   make install


### PR DESCRIPTION
I prefer make ... but there's no Makefile, so running `./configure` should be mentioned in the INSTALL file?