### PR TITLE
source-highlight: use esc256.style with esc256 formatter

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -476,7 +476,7 @@ has_colorizer () {
 			[[ -n $lang ]] && opt+=(-s "$lang")
 			style=esc
 			[[ $colors -ge 256 ]] && style=esc256
-			opt+=(--failsafe -f "$style") ;;
+			opt+=(--failsafe -f "$style" --style-file "$style".style) ;;
 		code2color|vimcolor)
 			opt=("$1")
 			[[ -n "$3" ]] && opt=(-l "$3" "$1") ;;


### PR DESCRIPTION
If only `-f esc256` is used, source-highlight doesn't take full advantage of the 256-color formatter. To get it to actually use a 256-color style, it's necessary to also specify `--style-file esc256.style`.

---

Before:

<img width="1308" height="1154" alt="image" src="https://github.com/user-attachments/assets/91bc5c3e-23d8-4a7a-ba54-cf812efa5933" />

---

After:

<img width="1308" height="1154" alt="image" src="https://github.com/user-attachments/assets/c6a1b04c-2cbf-4783-a262-1dacc94460b8" />
