### PR TITLE
Prefer batcat to bat

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ the author by email.
  **LESS** can be used to switch on colored less output (should contain -R).
 
  **LESSCOLORIZER** can be set to prefer a highlighting program from the following
- choices (`nvimpager` `bat` `batcat` `pygmentize` `source-highlight` `vimcolor` `code2color`).
+ choices (`nvimpager` `batcat` `bat` `pygmentize` `source-highlight` `vimcolor` `code2color`).
  Otherwise the first program in that list that is installed will be used, with
  the caveat that `bat` will use the [ansi theme](https://github.com/wofr06/lesspipe/issues/155#issuecomment-2312972276) instead of its default colors.
 

--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -430,7 +430,7 @@ has_colorizer () {
 	prog=${LESSCOLORIZER%% *}
 	[[ $prog == vimcolor ]] && ! has_cmd vim && ! has_cmd nvim && prog=
 
-	for i in nvimpager bat batcat pygmentize source-highlight vim nvim code2color ; do
+	for i in nvimpager batcat bat pygmentize source-highlight vim nvim code2color ; do
 		[[ -z $prog ]] && has_cmd "$i" && prog=$i
 		[[ $prog == "$i" ]] && ! has_cmd "$prog" && prog=
 	done

--- a/test.sh
+++ b/test.sh
@@ -125,7 +125,7 @@ if [[ -z $noaction ]]; then
 	[[ $TERM == *256* ]] && colors=256
 	command -v tput &>/dev/null && colors=$(tput colors)
 	if [[ "$colors" -lt 8 && -z "$LESSCOLORIZER" ]]; then
-		for i in nvimpager bat batcat pygmentize source-highlight vim nvim code2color ; do
+		for i in nvimpager batcat bat pygmentize source-highlight vim nvim code2color ; do
 			command -v "$i" &>/dev/null && export LESSCOLORIZER="$i" && break
 		done
 	fi
@@ -444,7 +444,7 @@ while IFS= read -r line || [[ -n $line ]]; do
 		needed="${comment##* needs }"
 		comment=${comment%%, needs*}
 		needed="${needed//html_converter/w3m|lynx|elinks|html2text}"
-		needed="${needed//colorizer/nvimpager|bat|batcat|pygmentize|source-highlight|vimcolor}"
+		needed="${needed//colorizer/nvimpager|batcat|bat|pygmentize|source-highlight|vimcolor}"
 	fi
 
 	if [[ $noaction == 1 ]]; then


### PR DESCRIPTION
`batcat` is an alternative name for the `bat` binary for situations when `bat` may already be taken by the Bacula Administration Tool.  Hence, if both are present, we should prefer `batcat` to `bat`.