### PR TITLE
When creating temporary files, prevent overwriting

### DIFF
--- a/lesspipe.sh
+++ b/lesspipe.sh
@@ -177,7 +177,7 @@ separatorline () {
 nexttmp () {
 	new=$(mktemp "$tmpdir/lesspipeXXXXXX")
 	new2="$new.${ft%%:*}"
-	mv "$new" "$new2"
+	mv -n "$new" "$new2"
 	echo "$new2"
 }
 


### PR DESCRIPTION
This is probably unnecessary, since we’re already using our own directory, but better safe than sorry.